### PR TITLE
Pass $HOME and $XDG_CONFIG_HOME to git to load git configuration

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -74,7 +74,7 @@ func (sd *stackediff) AmendCommit(ctx context.Context) {
 	mustgit("rebase origin/master -i --autosquash --autostash", nil)
 }
 
-// UpdatePullRequests implaments a stacked diff workflow on top of github.
+// UpdatePullRequests implements a stacked diff workflow on top of github.
 //  Each time it's called it compares the local branch unmerged commits
 //   with currently open pull requests in github.
 //  It will create a new pull request for all new commits, and update the
@@ -755,10 +755,15 @@ func git(argStr string, output *string) error {
 	envVarsToDerive := []string{
 		"SSH_AUTH_SOCK",
 		"SSH_AGENT_PID",
+		"HOME",
+		"XDG_CONFIG_HOME",
 	}
 	cmd.Env = []string{"EDITOR=/usr/bin/true"}
 	for _, env := range envVarsToDerive {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", env, os.Getenv(env)))
+		envval := os.Getenv(env)
+		if envval != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", env, envval))
+		}
 	}
 
 	if output != nil {


### PR DESCRIPTION
Closes: #31 

This will cause global gitconfig to be loaded, which has a side effect of using all the changes configured there.
This is sadly not the best, see `man git`:
```
       GIT_CONFIG_NOSYSTEM
           Whether to skip reading settings from the system-wide $(prefix)/etc/gitconfig file.
           This environment variable can be used along with $HOME and $XDG_CONFIG_HOME to create a
           predictable environment for a picky script, or you can set it temporarily to avoid
           using a buggy /etc/gitconfig file while waiting for someone with sufficient permissions
           to fix it.
```

As such, possible a better solution is to pre-load some git configuration beforehand with all env variables set, and then run git without these env vars set, but with temporarily setting these few git settings.