### PR TITLE
After merge cleanup branch error suppresion

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -193,10 +193,7 @@ func (sd *stackediff) MergePullRequests(ctx context.Context) {
 	sd.profiletimer.Step("MergePullRequests::merge pr")
 
 	if sd.config.CleanupRemoteBranch {
-		err := sd.gitcmd.Git(fmt.Sprintf("push -d origin %s", prToMerge.FromBranch), nil)
-		if err != nil {
-			fmt.Fprintf(sd.writer, "error deleting branch: %v\n", err)
-		}
+		sd.gitcmd.Git(fmt.Sprintf("push -d origin %s", prToMerge.FromBranch), nil)
 	}
 
 	// Close all the pull requests in the stack below the merged pr
@@ -211,10 +208,7 @@ func (sd *stackediff) MergePullRequests(ctx context.Context) {
 		sd.github.ClosePullRequest(ctx, pr)
 
 		if sd.config.CleanupRemoteBranch {
-			err := sd.gitcmd.Git(fmt.Sprintf("push -d origin %s", pr.FromBranch), nil)
-			if err != nil {
-				fmt.Fprintf(sd.writer, "error deleting branch: %v\n", err)
-			}
+			sd.gitcmd.Git(fmt.Sprintf("push -d origin %s", pr.FromBranch), nil)
 		}
 	}
 	sd.profiletimer.Step("MergePullRequests::close prs")


### PR DESCRIPTION
GitHub might also delete the branch, causing an error when trying
to delete a branch that's gone.
After merge make the branch cleanup command be best effort, with no error.

Fixes:#53