### PR TITLE
remove branch cleanup logic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,11 +30,10 @@ type RepoConfig struct {
 }
 
 type UserConfig struct {
-	ShowPRLink          bool `default:"true" yaml:"showPRLink"`
-	CleanupRemoteBranch bool `default:"true" yaml:"cleanupRemoteBranch"`
-	LogGitCommands      bool `default:"false" yaml:"logGitCommands"`
-	LogGitHubCalls      bool `default:"false" yaml:"logGitHubCalls"`
-	StatusBitsHeader    bool `default:"true" yaml:"statusBitsHeader"`
+	ShowPRLink       bool `default:"true" yaml:"showPRLink"`
+	LogGitCommands   bool `default:"false" yaml:"logGitCommands"`
+	LogGitHubCalls   bool `default:"false" yaml:"logGitHubCalls"`
+	StatusBitsHeader bool `default:"true" yaml:"statusBitsHeader"`
 
 	Stargazer bool `default:"false" yaml:"stargazer"`
 	RunCount  int  `default:"0" yaml:"runcount"`

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,6 @@ User specific configuration is saved to .spr.yml in the user home directory.
 | User Config         | Type | Default | Description                                                    |
 | ------------------- | ---- | ------- | -------------------------------------------------------------- |
 | showPRLink          | bool | true    | show full pull request http link                               |
-| cleanupRemoteBranch | bool | true    | delete remote branch after pull request merges                 |
 | logGitCommands      | bool | false   | logs all git commands to stdout                                |
 | logGitHubCalls      | bool | false   | logs all github api calls to stdout                            |
 | statusBitsHeader    | bool | true    | show status bits type headers                                  |

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -96,6 +96,10 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context) {
 		//   first - rebase all pull requests to master
 		//   then - update all pull requests
 		for _, pr := range githubInfo.PullRequests {
+			fmt.Printf("DEBUG 1: UpdatePullReqeust info:%v\n", githubInfo)
+			fmt.Printf("DEBUG 1: UpdatePullReqeust pr:%v\n", pr)
+			fmt.Printf("DEBUG 1: UpdatePullReqeust c:%v\n", pr.Commit)
+			fmt.Printf("DEBUG 1: UpdatePullReqeust prevcommit:%v\n", nil)
 			sd.github.UpdatePullRequest(ctx, githubInfo, pr, pr.Commit, nil)
 		}
 		sd.profiletimer.Step("UpdatePullRequests::ReparentPullRequestsToMaster")
@@ -122,6 +126,10 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context) {
 					if commitIndex > 0 {
 						prevCommit = &localCommits[commitIndex-1]
 					}
+					fmt.Printf("DEBUG 2: UpdatePullReqeust info:%v\n", githubInfo)
+					fmt.Printf("DEBUG 2: UpdatePullReqeust pr:%v\n", pr)
+					fmt.Printf("DEBUG 2: UpdatePullReqeust c:%v\n", c)
+					fmt.Printf("DEBUG 2: UpdatePullReqeust prevcommit:%v\n", prevCommit)
 					sd.github.UpdatePullRequest(ctx, githubInfo, pr, c, prevCommit)
 					pr.Commit = c
 				}
@@ -184,10 +192,6 @@ func (sd *stackediff) MergePullRequests(ctx context.Context) {
 	sd.github.MergePullRequest(ctx, prToMerge)
 	sd.profiletimer.Step("MergePullRequests::merge pr")
 
-	if sd.config.User.CleanupRemoteBranch {
-		sd.gitcmd.Git(fmt.Sprintf("push -d %s %s", sd.config.Repo.GitHubRemote, prToMerge.FromBranch), nil)
-	}
-
 	// Close all the pull requests in the stack below the merged pr
 	//  Before closing add a review comment with the pr that merged the commit.
 	for i := 0; i < prIndex; i++ {
@@ -198,10 +202,6 @@ func (sd *stackediff) MergePullRequests(ctx context.Context) {
 		sd.github.CommentPullRequest(ctx, pr, comment)
 
 		sd.github.ClosePullRequest(ctx, pr)
-
-		if sd.config.User.CleanupRemoteBranch {
-			sd.gitcmd.Git(fmt.Sprintf("push -d %s %s", sd.config.Repo.GitHubRemote, pr.FromBranch), nil)
-		}
 	}
 	sd.profiletimer.Step("MergePullRequests::close prs")
 


### PR DESCRIPTION
when a branch gets cleaned up after a merged pr, it sometimes ends up
 closing the next pr in the stack.

fixes: 105

commit-id:2269dd9a