### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,30 +6,38 @@ import (
 
 func TestGetRepoDetailsFromRemote(t *testing.T) {
 	type testCase struct {
-		remote    string
-		repoOwner string
-		repoName  string
-		match     bool
+		remote     string
+		githubHost string
+		repoOwner  string
+		repoName   string
+		match      bool
 	}
 	testCases := []testCase{
-		{"origin  https://github.com/r2/d2.git (push)", "r2", "d2", true},
-		{"origin  https://github.com/r2/d2.git (fetch)", "", "", false},
-		{"origin  https://github.com/r2/d2 (push)", "r2", "d2", true},
+		{"origin  https://github.com/r2/d2.git (push)", "github.com", "r2", "d2", true},
+		{"origin  https://github.com/r2/d2.git (fetch)", "", "", "", false},
+		{"origin  https://github.com/r2/d2 (push)", "github.com", "r2", "d2", true},
 
-		{"origin  ssh://git@github.com/r2/d2.git (push)", "r2", "d2", true},
-		{"origin  ssh://git@github.com/r2/d2.git (fetch)", "", "", false},
-		{"origin  ssh://git@github.com/r2/d2 (push)", "r2", "d2", true},
+		{"origin  ssh://git@github.com/r2/d2.git (push)", "github.com", "r2", "d2", true},
+		{"origin  ssh://git@github.com/r2/d2.git (fetch)", "", "", "", false},
+		{"origin  ssh://git@github.com/r2/d2 (push)", "github.com", "r2", "d2", true},
 
-		{"origin  git@github.com:r2/d2.git (push)", "r2", "d2", true},
-		{"origin  git@github.com:r2/d2.git (fetch)", "", "", false},
-		{"origin  git@github.com:r2/d2 (push)", "r2", "d2", true},
+		{"origin  git@github.com:r2/d2.git (push)", "github.com", "r2", "d2", true},
+		{"origin  git@github.com:r2/d2.git (fetch)", "", "", "", false},
+		{"origin  git@github.com:r2/d2 (push)", "github.com", "r2", "d2", true},
 
-		{"origin	https://github.com/r2/d2-a.git (push)", "r2", "d2-a", true},
-		{"origin	https://github.com/r2/d2_a.git (push)", "r2", "d2_a", true},
+		{"origin  git@gh.enterprise.com:r2/d2.git (push)", "gh.enterprise.com", "r2", "d2", true},
+		{"origin  git@gh.enterprise.com:r2/d2.git (fetch)", "", "", "", false},
+		{"origin  git@gh.enterprise.com:r2/d2 (push)", "gh.enterprise.com", "r2", "d2", true},
+
+		{"origin	https://github.com/r2/d2-a.git (push)", "github.com", "r2", "d2-a", true},
+		{"origin	https://github.com/r2/d2_a.git (push)", "github.com", "r2", "d2_a", true},
 	}
 	for i, testCase := range testCases {
 		t.Logf("Testing %v %q", i, testCase.remote)
-		repoOwner, repoName, match := getRepoDetailsFromRemote(testCase.remote)
+		githubHost, repoOwner, repoName, match := getRepoDetailsFromRemote(testCase.remote)
+		if githubHost != testCase.githubHost {
+			t.Fatalf("Wrong \"githubHost\" returned for test case %v, expected %q, got %q", i, testCase.githubHost, githubHost)
+		}
 		if repoOwner != testCase.repoOwner {
 			t.Fatalf("Wrong \"repoOwner\" returned for test case %v, expected %q, got %q", i, testCase.repoOwner, repoOwner)
 		}

--- a/github/pullrequest.go
+++ b/github/pullrequest.go
@@ -167,8 +167,8 @@ func (pr *PullRequest) String(config *config.Config) string {
 
 	prInfo := fmt.Sprintf("%3d", pr.Number)
 	if config.User.ShowPRLink {
-		prInfo = fmt.Sprintf("github.com/%s/%s/pull/%d",
-			config.Repo.GitHubRepoOwner, config.Repo.GitHubRepoName, pr.Number)
+		prInfo = fmt.Sprintf("%s/%s/%s/pull/%d",
+			config.Repo.GitHubHost, config.Repo.GitHubRepoOwner, config.Repo.GitHubRepoName, pr.Number)
 	}
 
 	line := fmt.Sprintf("%s %s : %s", prStatus, prInfo, pr.Title)

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -187,8 +187,8 @@ func (sd *stackediff) MergePullRequests(ctx context.Context) {
 	for i := 0; i < prIndex; i++ {
 		pr := githubInfo.PullRequests[i]
 		comment := fmt.Sprintf(
-			"commit MERGED in pull request [#%d](https://github.com/%s/%s/pull/%d)",
-			prToMerge.Number, sd.config.Repo.GitHubRepoOwner, sd.config.Repo.GitHubRepoName, prToMerge.Number)
+			"commit MERGED in pull request [#%d](https://%s/%s/%s/pull/%d)",
+			prToMerge.Number, sd.config.Repo.GitHubHost, sd.config.Repo.GitHubRepoOwner, sd.config.Repo.GitHubRepoName, prToMerge.Number)
 		sd.github.CommentPullRequest(ctx, pr, comment)
 
 		sd.github.ClosePullRequest(ctx, pr)


### PR DESCRIPTION
* Parse custom GitHub hostnames from Git remote URLs;
* Allow setting GitHub hostname explicitly in the config;
* Connect to hosts other than `github.com` with `githubv4.NewEnterpriseClient`
* Updated unit tests.

Also tested with our GitHub enterprise server.