### PR TITLE
Wrap commit body in code area in PR message

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
+	"mvdan.cc/xurls"
 )
 
 type hubCLIConfig map[string][]struct {
@@ -300,11 +301,40 @@ func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest) string 
 	return buf.String()
 }
 
+var issueReferenceRegex = regexp.MustCompile(`(?mi)((close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s)?([a-zA-Z-]+\/[a-zA-Z-]+#\d+|#\d+|https?://.+?/[a-zA-Z-]+\/[a-zA-Z-]+/(issues|pull)/\d+)`)
+
+// linkifyPlainLinks replaces plain links in the body by <a> tags, which makes them clickable
+// inside a GitHub code area.
+func linkifyPlainLinks(body string) string {
+	return string(xurls.Relaxed.ReplaceAll([]byte(body), []byte("<a href=\"$1\">$1</a>")))
+}
+
+func wrapInMarkdown(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return ""
+	}
+
+	// Extract issue references for GitHub to find them outside the code block
+	refs := issueReferenceRegex.FindAllString(s, -1)
+	var trailer bytes.Buffer
+	if len(refs) > 0 {
+		trailer.WriteString("**Issue references**: \n")
+		for _, ref := range refs {
+			trailer.WriteString(fmt.Sprintf("\n - %s", ref))
+		}
+	}
+
+	return fmt.Sprintf("<pre>\n%s\n</pre>\n%s", linkifyPlainLinks(s), trailer.String())
+}
+
 func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 	if len(stack) <= 1 {
-		return commit.Body
+		return wrapInMarkdown(commit.Body)
 	}
-	return fmt.Sprintf("**Stack**:\n%s\n\n%s", formatStackMarkdown(commit, stack), commit.Body)
+
+	return fmt.Sprintf("**Stack**:\n%s\n\n%s",
+		formatStackMarkdown(commit, stack),
+		wrapInMarkdown(commit.Body))
 }
 
 func (c *client) UpdatePullRequest(ctx context.Context,

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ejoffe/rake v0.2.3
 	github.com/google/uuid v1.2.0
 	github.com/jessevdk/go-flags v1.5.0
+	github.com/mvdan/xurls v1.1.0 // indirect
 	github.com/rs/zerolog v1.22.0
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
@@ -15,4 +16,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+	mvdan.cc/xurls v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mvdan/xurls v1.1.0 h1:OpuDelGQ1R1ueQ6sSryzi6P+1RtBpfQHM8fJwlE45ww=
+github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -401,6 +403,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+mvdan.cc/xurls v1.1.0 h1:kj0j2lonKseISJCiq1Tfk+iTv65dDGCl0rTbanXJGGc=
+mvdan.cc/xurls v1.1.0/go.mod h1:TNWuhvo+IqbUCmtUIb/3LJSQdrzel8loVpgFm0HikbI=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
**Stack**:
- #155
- #156
- #154
- #153
- #152
- #151
- #150 ⮜
- #149
- #148
- #147


<pre>
Commit messages are not guaranteed to be valid Markdown.
Wrapping them in a code area guarantees that the original
formatting is preserved (say, ASCII art).

This matches what GitHub itself does when rendering commits.

This might be a matter of taste - maybe some people *do*
write valid Markdown in their commits and want to keep the
existing behavior - should we make it a config option?
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*