### PR TITLE
Do not panic on runtime errors

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -461,7 +461,11 @@ func (sd *stackediff) mustgit(argStr string, output *string) {
 
 func check(err error) {
 	if err != nil {
-		panic(err)
+		if os.Getenv("SPR_DEBUG") == "1" {
+			panic(err)
+		}
+		fmt.Printf("error: %s\n", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
**Stack**:
- #155
- #156
- #154
- #153 ⮜
- #152
- #151
- #150
- #149
- #148
- #147


<pre>
Panics are usually reserved for programming errors
(i.e. a bug in the code). This code path is frequently hit for
user errors, like running "git amend" with an empty staging area.
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*