### PR TITLE
Use emojis for "spr status" output

### DIFF
--- a/.spr.yml
+++ b/.spr.yml
@@ -2,6 +2,6 @@ githubRepoOwner: ejoffe
 githubRepoName: spr
 githubHost: github.com
 requireChecks: true
-requireApproval: false
+requireApproval: true
 githubRemote: origin
 githubBranch: master

--- a/github/pullrequest.go
+++ b/github/pullrequest.go
@@ -123,9 +123,19 @@ func (pr *PullRequest) Ready(config *config.Config) bool {
 	return true
 }
 
-const checkmark = "\xE2\x9C\x94"
-const crossmark = "\xE2\x9C\x97"
-const middledot = "\xC2\xB7"
+// Terminal escape codes for colors
+const (
+	colorReset = "\033[0m"
+	colorRed   = "\033[31m"
+	colorGreen = "\033[32m"
+	colorBlue  = "\033[34m"
+)
+
+const checkmark = colorGreen + "✅" + colorReset
+const crossmark = colorRed + "❌" + colorReset
+const hourglass = colorBlue + "⌛" + colorReset
+const questionmark = "❓"
+const empty = "➖"
 
 // StatusString returs a string representation of the merge status bits
 func (pr *PullRequest) StatusString(config *config.Config) string {
@@ -140,7 +150,7 @@ func (pr *PullRequest) StatusString(config *config.Config) string {
 			statusString += crossmark
 		}
 	} else {
-		statusString += "-"
+		statusString += empty
 	}
 
 	if pr.MergeStatus.NoConflicts {
@@ -192,16 +202,16 @@ func (cs checkStatus) String(config *config.Config) string {
 	if config.Repo.RequireChecks {
 		switch cs {
 		case CheckStatusUnknown:
-			return "?"
+			return questionmark
 		case CheckStatusPending:
-			return middledot
+			return hourglass
 		case CheckStatusFail:
 			return crossmark
 		case CheckStatusPass:
 			return checkmark
 		default:
-			return "?"
+			return questionmark
 		}
 	}
-	return "-"
+	return empty
 }

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -471,8 +471,8 @@ func check(err error) {
 
 var detailMessage = `
  ┌─ github checks pass
- │┌── pull request approved
- ││┌─── no merge conflicts
- │││┌──── stack check
- ││││
+ │ ┌── pull request approved
+ │ │ ┌─── no merge conflicts
+ │ │ │ ┌──── stack check
+ │ │ │ │
 `


### PR DESCRIPTION
<pre>
Easier to get an overview of the current stack.

Might be a matter of personal taste, we could
make it a configuration flag instead? Users might not
have a terminal that supports emoji (like urxvt?).
</pre>
