### PR TITLE
Support the "gh" CLI tool in addition to "hub"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,7 +86,10 @@ func ParseConfig(gitcmd git.GitInterface) *Config {
 		rake.YamlFileSource(UserConfigFilePath()),
 	)
 
-	cfg.User.RunCount = cfg.User.RunCount + 1
+	if !cfg.User.Stargazer {
+		cfg.User.RunCount = cfg.User.RunCount + 1
+	}
+
 	rake.LoadSources(cfg.User,
 		rake.YamlFileWriter(UserConfigFilePath()))
 

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -334,7 +334,13 @@ func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 
 	return fmt.Sprintf("**Stack**:\n%s\n\n%s",
 		formatStackMarkdown(commit, stack),
-		wrapInMarkdown(commit.Body))
+		addManualMergeNotice(wrapInMarkdown(commit.Body)))
+}
+
+func addManualMergeNotice(body string) string {
+	return body + "\n\n" +
+		"⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). " +
+		"Do not merge manually using the UI - doing so may have unexpected results.*"
 }
 
 func (c *client) UpdatePullRequest(ctx context.Context,

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -284,10 +284,17 @@ func (c *client) CreatePullRequest(ctx context.Context,
 	return pr
 }
 
-func formatStackMarkdown(stack []*github.PullRequest) string {
+func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest) string {
 	var buf bytes.Buffer
 	for i := len(stack) - 1; i >= 0; i-- {
-		buf.WriteString(fmt.Sprintf("- #%d\n", stack[i].Number))
+		isCurrent := stack[i].Commit == commit
+		var suffix string
+		if isCurrent {
+			suffix = " ⮜"
+		} else {
+			suffix = ""
+		}
+		buf.WriteString(fmt.Sprintf("- #%d%s\n", stack[i].Number, suffix))
 	}
 
 	return buf.String()
@@ -297,7 +304,7 @@ func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 	if len(stack) <= 1 {
 		return commit.Body
 	}
-	return fmt.Sprintf("**Stack**:\n%s\n\n%s", formatStackMarkdown(stack), commit.Body)
+	return fmt.Sprintf("**Stack**:\n%s\n\n%s", formatStackMarkdown(commit, stack), commit.Body)
 }
 
 func (c *client) UpdatePullRequest(ctx context.Context,

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
+	"mvdan.cc/xurls"
 )
 
 type hubCLIConfig map[string][]struct {
@@ -300,11 +301,40 @@ func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest) string 
 	return buf.String()
 }
 
+var issueReferenceRegex = regexp.MustCompile(`(?mi)((close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s)?([a-zA-Z-]+\/[a-zA-Z-]+#\d+|#\d+|https?://.+?/[a-zA-Z-]+\/[a-zA-Z-]+/(issues|pull)/\d+)`)
+
+// linkifyPlainLinks replaces plain links in the body by <a> tags, which makes them clickable
+// inside a GitHub code area.
+func linkifyPlainLinks(body string) string {
+	return string(xurls.Relaxed.ReplaceAll([]byte(body), []byte("<a href=\"$1\">$1</a>")))
+}
+
+func wrapInMarkdown(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return ""
+	}
+
+	// Extract issue references for GitHub to find them outside the code block
+	refs := issueReferenceRegex.FindAllString(s, -1)
+	var trailer bytes.Buffer
+	if len(refs) > 0 {
+		trailer.WriteString("**Issue references**: \n")
+		for _, ref := range refs {
+			trailer.WriteString(fmt.Sprintf("\n - %s", ref))
+		}
+	}
+
+	return fmt.Sprintf("<pre>\n%s\n</pre>\n%s", linkifyPlainLinks(s), trailer.String())
+}
+
 func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 	if len(stack) <= 1 {
-		return commit.Body
+		return wrapInMarkdown(commit.Body)
 	}
-	return fmt.Sprintf("**Stack**:\n%s\n\n%s", formatStackMarkdown(commit, stack), commit.Body)
+
+	return fmt.Sprintf("**Stack**:\n%s\n\n%s",
+		formatStackMarkdown(commit, stack),
+		wrapInMarkdown(commit.Body))
 }
 
 func (c *client) UpdatePullRequest(ctx context.Context,

--- a/github/pullrequest.go
+++ b/github/pullrequest.go
@@ -167,7 +167,7 @@ func (pr *PullRequest) String(config *config.Config) string {
 
 	prInfo := fmt.Sprintf("%3d", pr.Number)
 	if config.User.ShowPRLink {
-		prInfo = fmt.Sprintf("%s/%s/%s/pull/%d",
+		prInfo = fmt.Sprintf("https://%s/%s/%s/pull/%d",
 			config.Repo.GitHubHost, config.Repo.GitHubRepoOwner, config.Repo.GitHubRepoName, pr.Number)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ejoffe/rake v0.2.3
 	github.com/google/uuid v1.2.0
 	github.com/jessevdk/go-flags v1.5.0
+	github.com/mvdan/xurls v1.1.0 // indirect
 	github.com/rs/zerolog v1.22.0
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
@@ -15,4 +16,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+	mvdan.cc/xurls v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mvdan/xurls v1.1.0 h1:OpuDelGQ1R1ueQ6sSryzi6P+1RtBpfQHM8fJwlE45ww=
+github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -401,6 +403,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+mvdan.cc/xurls v1.1.0 h1:kj0j2lonKseISJCiq1Tfk+iTv65dDGCl0rTbanXJGGc=
+mvdan.cc/xurls v1.1.0/go.mod h1:TNWuhvo+IqbUCmtUIb/3LJSQdrzel8loVpgFm0HikbI=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,19 @@ Installation
 ### Manual
 Download the pre-compiled binaries from the [releases page](https://github.com/ejoffe/spr/releases) and copy to your bin path.
 
+### From source
+
+Assuming you want to put the binaries into `~/.local/bin`:
+
+```
+git clone https://github.com/ejoffe/spr
+cd spr
+go build -o ~/.local/bin/git-spr github.com/ejoffe/spr/cmd/spr
+go build -o ~/.local/bin/git-amend github.com/ejoffe/spr/cmd/amend
+go build -o ~/.local/bin/spr_commit_hook github.com/ejoffe/spr/cmd/commithook
+go build -o ~/.local/bin/spr_reword_helper github.com/ejoffe/spr/cmd/reword
+```
+
 Workflow
 --------
 Commit your changes to a branch as you normally do. Note that every commit will end up becoming a pull request.

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -461,7 +461,11 @@ func (sd *stackediff) mustgit(argStr string, output *string) {
 
 func check(err error) {
 	if err != nil {
-		panic(err)
+		if os.Getenv("SPR_DEBUG") == "1" {
+			panic(err)
+		}
+		fmt.Printf("error: %s\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -102,7 +102,7 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context) {
 	}
 	for _, pr := range githubInfo.PullRequests {
 		if _, found := localCommitMap[pr.Commit.CommitID]; !found {
-			sd.github.CommentPullRequest(ctx, pr, "closing pull request : commit has gone away")
+			sd.github.CommentPullRequest(ctx, pr, "Closing pull request: commit has gone away")
 			sd.github.ClosePullRequest(ctx, pr)
 		} else {
 			validPullRequests = append(validPullRequests, pr)
@@ -219,7 +219,7 @@ func (sd *stackediff) MergePullRequests(ctx context.Context) {
 	for i := 0; i < prIndex; i++ {
 		pr := githubInfo.PullRequests[i]
 		comment := fmt.Sprintf(
-			"commit MERGED in pull request [#%d](https://%s/%s/%s/pull/%d)",
+			"✓ Commit merged in pull request [#%d](https://%s/%s/%s/pull/%d)",
 			prToMerge.Number, sd.config.Repo.GitHubHost, sd.config.Repo.GitHubRepoOwner, sd.config.Repo.GitHubRepoName, prToMerge.Number)
 		sd.github.CommentPullRequest(ctx, pr, comment)
 		sd.github.ClosePullRequest(ctx, pr)


### PR DESCRIPTION
**Stack**:
- #155
- #156 ⮜
- #154
- #153
- #152
- #151
- #150
- #149
- #148
- #147


<pre>
Turns out "hub" is deprecated and GitHub wants you
to use this one instead: <a href="https://cli.github.com">https://cli.github.com</a>

From playing with it, it seems strictly superior to hub
since it does browser-based authentication and has a much
wider array of supported operations.

commit-id:48660ea6
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*