### PR TITLE
Update PR description formatting.

### DIFF
--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -50,26 +50,22 @@ It even includes some **markdown** formatting.`}
 			stack:       []*github.PullRequest{},
 		},
 		{
-			description: `<pre>
-This body describes my nice PR.
-It even includes some **markdown** formatting.
-</pre>
-`,
+			description: `This body describes my nice PR.
+It even includes some **markdown** formatting.`,
 			commit: descriptiveCommit,
 			stack: []*github.PullRequest{
 				&github.PullRequest{Number: 2, Commit: descriptiveCommit},
 			},
 		},
 		{
-			description: `**Stack**:
+			description: `This body describes my nice PR.
+It even includes some **markdown** formatting.
+
+---
+
+**Stack**:
 - #2 ⮜
 - #1
-
-
-<pre>
-This body describes my nice PR.
-It even includes some **markdown** formatting.
-</pre>
 
 
 ⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*`,


### PR DESCRIPTION
Previously, the commit description was dropped in after the stack list and was in a pre-formatted block, which removes any markdown formatting and other niceties of description commit bodies.

This instead pulls the commit body to the top, and adds a horizontal divider, after which the SPR stack and other trailer info is added. This keeps the PR description more in line with the commit message, while still including the Stack info.

---

This also adds unit tests for the description formatting. The first commit in this PR adds just the tests for the existing description formatting. The 2nd commit then updates the formatting output. Should make reviewing easier by reviewing each commit separately.