### PR TITLE
Use `-c core.editor` git flag instead of `EDITOR` environment variable

### DIFF
--- a/git/realgit/realcmd.go
+++ b/git/realgit/realcmd.go
@@ -46,11 +46,11 @@ func (c *gitcmd) GitWithEditor(argStr string, output *string, editorCmd string) 
 	if c.config.User.LogGitCommands {
 		fmt.Printf("> git %s\n", argStr)
 	}
-	args := strings.Split(argStr, " ")
+	args := []string{"-c", fmt.Sprintf("core.editor=%s", editorCmd)}
+	args = append(args, strings.Split(argStr, " ")...)
 	cmd := exec.Command("git", args...)
 	cmd.Dir = c.rootdir
 
-	cmd.Env = []string{fmt.Sprintf("EDITOR=%s", editorCmd)}
 	for _, env := range os.Environ() {
 		parts := strings.SplitN(env, "=", 2)
 


### PR DESCRIPTION
If a user overrides `core.editor` in their `.gitconfig`, that setting
takes precedence over `$EDITOR`, which breaks the command. Instead,
use the `-c` flag, which has precedence over `.gitconfig`.