### PR TITLE
Add support for creating draft PRs.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type UserConfig struct {
 	LogGitCommands   bool `default:"true" yaml:"logGitCommands"`
 	LogGitHubCalls   bool `default:"true" yaml:"logGitHubCalls"`
 	StatusBitsHeader bool `default:"true" yaml:"statusBitsHeader"`
+	CreateDraftPRs   bool `default:"false" yaml:"createDraftPRs"`
 
 	Stargazer bool `default:"false" yaml:"stargazer"`
 	RunCount  int  `default:"0" yaml:"runcount"`

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -303,6 +303,7 @@ func (c *client) CreatePullRequest(ctx context.Context,
 		HeadRefName:  githubv4.String(headRefName),
 		Title:        githubv4.String(commit.Subject),
 		Body:         &commitBody,
+		Draft:        githubv4.NewBoolean(githubv4.Boolean(c.config.User.CreateDraftPRs)),
 	}
 	err := c.api.Mutate(ctx, &mutation, input, nil)
 	check(err)

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ User specific configuration is saved to .spr.yml in the user home directory.
 | logGitCommands      | bool | true    | logs all git commands to stdout                                   |
 | logGitHubCalls      | bool | true    | logs all github api calls to stdout                               |
 | statusBitsHeader    | bool | true    | show status bits type headers                                     |
+| createDraftPRs      | bool | false   | new pull requests are created as draft                            |
 
 Happy Coding!
 -------------


### PR DESCRIPTION
I prefer to use the GitHub UI to do a last check on the generated PRs
before sending them for review. This change adds a user config option
`createDraftPRs` that, when set to true, creates new PRs as drafts.

commit-id:d78551e5