### PR TITLE
WIP add reviewers using `git spr u [-r NAME] [--reviewer NAME]`

### DIFF
--- a/.spr.yml
+++ b/.spr.yml
@@ -1,6 +1,8 @@
-githubRepoOwner: ejoffe
+githubRepoOwner: wade13
 githubRepoName: spr
 githubHost: github.com
+reviewers:
+- ejoffe
 requireChecks: true
 requireApproval: true
 githubRemote: origin

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -136,11 +136,19 @@ VERSION: {{.Version}}
 				Aliases: []string{"u", "up"},
 				Usage:   "Update and create pull requests for updated commits in the stack",
 				Action: func(c *cli.Context) error {
+					if c.IsSet("reviewer") {
+						stackedpr.Reviewers = append(stackedpr.Reviewers, c.StringSlice("reviewer")...)
+					}
 					stackedpr.UpdatePullRequests(ctx)
 					return nil
 				},
 				Flags: []cli.Flag{
 					detailFlag,
+					&cli.StringSliceFlag{
+						Name:    "reviewer",
+						Aliases: []string{"r"},
+						Usage:   "Assign reviewers to all modified pull requests",
+					},
 				},
 			},
 			{

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ type RepoConfig struct {
 	GitHubRepoName  string `yaml:"githubRepoName"`
 	GitHubHost      string `default:"github.com" yaml:"githubHost"`
 
+	Reviewers []string `yaml:"reviewers"`
+
 	RequireChecks   bool `default:"true" yaml:"requireChecks"`
 	RequireApproval bool `default:"true" yaml:"requireApproval"`
 

--- a/github/pullrequest.go
+++ b/github/pullrequest.go
@@ -17,6 +17,7 @@ type PullRequest struct {
 	ToBranch   string
 	Commit     git.Commit
 	Title      string
+	Reviewers  []string
 
 	MergeStatus PullRequestMergeStatus
 	Merged      bool


### PR DESCRIPTION
I'm not sure where to make the graphQL APIs to resolve the AssigneeIDs
field in UpdatePullRequestInput.

This is a suggested API in relation to Issue #145.

```console
$ cat .spr.yml
githubRepoOwner: wade13
githubRepoName: spr
githubHost: github.com
reviewers:
- ejoffe
requireChecks: true
requireApproval: true
githubRemote: origin
githubBranch: master

$ go run ./cmd/spr u -r wade13
> git rev-parse --show-toplevel
reviewers: [wade13 ejoffe]
> git fetch
> git rebase origin/master --autostash
> github fetch pull requests
> git branch
> git log origin/master..HEAD
> git status --porcelain --untracked-files=no
> github fetch pull requests
> git branch
pull request stack is empty
```