### PR TITLE
github: use a more common left-arrow for PR descriptions

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -379,7 +379,7 @@ func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest) string 
 		isCurrent := stack[i].Commit == commit
 		var suffix string
 		if isCurrent {
-			suffix = " ⮜"
+			suffix = " ⬅"
 		} else {
 			suffix = ""
 		}

--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -64,7 +64,7 @@ It even includes some **markdown** formatting.
 ---
 
 **Stack**:
-- #2 ⮜
+- #2 ⬅
 - #1
 
 


### PR DESCRIPTION
As discussed in #200, at least Ubuntu does not support the current
left-arrow symbol "⮜". While not the best choice, "Leftwards Black
Arrow" is at least more available, it would seem.