### PR TITLE
Turn off colors when reading branch and log

### DIFF
--- a/git/mockgit/mockgit.go
+++ b/git/mockgit/mockgit.go
@@ -63,7 +63,7 @@ func (m *Mock) ExpectFetch() {
 }
 
 func (m *Mock) ExpectLogAndRespond(commits []*git.Commit) {
-	m.expect("git log origin/master..HEAD").commitRespond(commits)
+	m.expect("git log --no-color origin/master..HEAD").commitRespond(commits)
 }
 
 func (m *Mock) ExpectPushCommits(commits []*git.Commit) {

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -611,7 +611,7 @@ func (c *client) ClosePullRequest(ctx context.Context, pr *github.PullRequest) {
 
 func getLocalBranchName(gitcmd git.GitInterface) string {
 	var output string
-	err := gitcmd.Git("branch", &output)
+	err := gitcmd.Git("branch --no-color", &output)
 	check(err)
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -303,7 +303,7 @@ func (sd *stackediff) ProfilingSummary() {
 // getLocalCommitStack returns a list of unmerged commits
 func (sd *stackediff) getLocalCommitStack() []git.Commit {
 	var commitLog string
-	logCommand := fmt.Sprintf("log %s/%s..HEAD",
+	logCommand := fmt.Sprintf("log --no-color %s/%s..HEAD",
 		sd.config.Repo.GitHubRemote, sd.config.Repo.GitHubBranch)
 	sd.mustgit(logCommand, &commitLog)
 	commits, valid := sd.parseLocalCommitStack(commitLog)


### PR DESCRIPTION
The commit log and git branch parsing was not working when my commands
were getting colorized.  Explicitly pass --no-color to these two
commands to turn off colors.
