### PR TITLE
Remove code left over from pre-formatting message

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -389,37 +389,9 @@ func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest) string 
 	return buf.String()
 }
 
-var issueReferenceRegex = regexp.MustCompile(`(?mi)((close|closes|closed|fix|fixes|fixed|ref|resolve|resolves|resolved)\s)?([a-zA-Z-]+\/[a-zA-Z-]+#\d+|#\d+|https?://.+?/[a-zA-Z-]+\/[a-zA-Z-]+/(issues|pull)/\d+)`)
-
-// linkifyPlainLinks replaces plain links in the body by <a> tags, which makes them clickable
-// inside a GitHub code area.
-func linkifyPlainLinks(body string) string {
-	return string(xurls.Relaxed.ReplaceAll([]byte(body), []byte("<a href=\"$1\">$1</a>")))
-}
-
-func wrapInMarkdown(s string) string {
-	if strings.TrimSpace(s) == "" {
-		return ""
-	}
-
-	// Extract issue references for GitHub to find them outside the code block
-	refs := issueReferenceRegex.FindAllString(s, -1)
-	var trailer bytes.Buffer
-	if len(refs) > 0 {
-		trailer.WriteString("**Issue references**: \n")
-		for _, ref := range refs {
-			trailer.WriteString(fmt.Sprintf("\n - %s", ref))
-		}
-	}
-
-	return fmt.Sprintf("%s\n\n%s", linkifyPlainLinks(s), trailer.String())
-}
-
 func formatBody(commit git.Commit, stack []*github.PullRequest) string {
-	body := wrapInMarkdown(commit.Body)
-
 	if len(stack) <= 1 {
-		return strings.TrimSpace(body)
+		return strings.TrimSpace(commit.Body)
 	}
 
 	if body == "" {
@@ -428,7 +400,7 @@ func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 	}
 
 	return fmt.Sprintf("%s---\n\n**Stack**:\n%s",
-		body,
+		commit.Body,
 		addManualMergeNotice(formatStackMarkdown(commit, stack)))
 }
 

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
-	"mvdan.cc/xurls"
 )
 
 // hub cli config (https://hub.github.com)
@@ -394,7 +393,7 @@ func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 		return strings.TrimSpace(commit.Body)
 	}
 
-	if body == "" {
+	if commit.Body == "" {
 		return fmt.Sprintf("**Stack**:\n%s",
 			addManualMergeNotice(formatStackMarkdown(commit, stack)))
 	}

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -398,7 +398,7 @@ func formatBody(commit git.Commit, stack []*github.PullRequest) string {
 			addManualMergeNotice(formatStackMarkdown(commit, stack)))
 	}
 
-	return fmt.Sprintf("%s---\n\n**Stack**:\n%s",
+	return fmt.Sprintf("%s\n\n---\n\n**Stack**:\n%s",
 		commit.Body,
 		addManualMergeNotice(formatStackMarkdown(commit, stack)))
 }


### PR DESCRIPTION
Once upon a time, the commit message body was included in the PR description inside a pre-formatted code block. This did not allow for Markdown formatting, so it was removed in 1606b8ff251c293136419852f4cb9995734dcadc, but the code to wrap links in `<a>` tags and extract issue references was not removed. This code is now not needed and messes up other formatting.

Fixes https://github.com/ejoffe/spr/issues/237