### PR TITLE
amend: replace [] with ()

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -59,9 +59,9 @@ func (sd *stackediff) AmendCommit(ctx context.Context) {
 	}
 
 	if len(localCommits) == 1 {
-		fmt.Fprintf(sd.output, "Commit to amend [%d]: ", 1)
+		fmt.Fprintf(sd.output, "Commit to amend (%d): ", 1)
 	} else {
-		fmt.Fprintf(sd.output, "Commit to amend [%d-%d]: ", 1, len(localCommits))
+		fmt.Fprintf(sd.output, "Commit to amend (%d-%d): ", 1, len(localCommits))
 	}
 
 	reader := bufio.NewReader(sd.input)

--- a/spr/spr_test.go
+++ b/spr/spr_test.go
@@ -445,7 +445,7 @@ func TestAmendOneCommit(t *testing.T) {
 	gitmock.ExpectFixup(c1.CommitHash)
 	input.WriteString("1")
 	s.AmendCommit(ctx)
-	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend [1]: ", output.String())
+	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend (1): ", output.String())
 }
 
 func TestAmendTwoCommits(t *testing.T) {
@@ -467,7 +467,7 @@ func TestAmendTwoCommits(t *testing.T) {
 	gitmock.ExpectFixup(c2.CommitHash)
 	input.WriteString("1")
 	s.AmendCommit(ctx)
-	assert.Equal(" 2 : 00000001 : test commit 1\n 1 : 00000002 : test commit 2\nCommit to amend [1-2]: ", output.String())
+	assert.Equal(" 2 : 00000001 : test commit 1\n 1 : 00000002 : test commit 2\nCommit to amend (1-2): ", output.String())
 }
 
 func TestAmendInvalidInput(t *testing.T) {
@@ -484,19 +484,19 @@ func TestAmendInvalidInput(t *testing.T) {
 	gitmock.ExpectLogAndRespond([]*git.Commit{&c1})
 	input.WriteString("a")
 	s.AmendCommit(ctx)
-	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend [1]: Invalid input\n", output.String())
+	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend (1): Invalid input\n", output.String())
 	output.Reset()
 
 	gitmock.ExpectLogAndRespond([]*git.Commit{&c1})
 	input.WriteString("0")
 	s.AmendCommit(ctx)
-	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend [1]: Invalid input\n", output.String())
+	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend (1): Invalid input\n", output.String())
 	output.Reset()
 
 	gitmock.ExpectLogAndRespond([]*git.Commit{&c1})
 	input.WriteString("2")
 	s.AmendCommit(ctx)
-	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend [1]: Invalid input\n", output.String())
+	assert.Equal(" 1 : 00000001 : test commit 1\nCommit to amend (1): Invalid input\n", output.String())
 	output.Reset()
 }
 


### PR DESCRIPTION
The [] misled me into thinking there was a default.