### PR TITLE
Add 'PreserveTitleAndBody' configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,9 @@ type UserConfig struct {
 	LogGitHubCalls   bool `default:"true" yaml:"logGitHubCalls"`
 	StatusBitsHeader bool `default:"true" yaml:"statusBitsHeader"`
 	StatusBitsEmojis bool `default:"true" yaml:"statusBitsEmojis"`
-	CreateDraftPRs   bool `default:"false" yaml:"createDraftPRs"`
+
+	CreateDraftPRs       bool `default:"false" yaml:"createDraftPRs"`
+	PreserveTitleAndBody bool `default:"false" yaml:"preserveTitleAndBody"`
 
 	Stargazer bool `default:"false" yaml:"stargazer"`
 	RunCount  int  `default:"0" yaml:"runcount"`

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -441,6 +441,10 @@ func (c *client) UpdatePullRequest(ctx context.Context,
 		Title:         &subject,
 		Body:          &body,
 	}
+	if c.config.User.PreserveTitleAndBody {
+		input.Title = nil
+		input.Body = nil
+	}
 	err := c.api.Mutate(ctx, &mutation, input, nil)
 	if err != nil {
 		log.Fatal().

--- a/readme.md
+++ b/readme.md
@@ -153,25 +153,26 @@ When the script is run for the first time two config files are created.
 Repository configuration is saved to .spr.yml in the repository base directory. 
 User specific configuration is saved to .spr.yml in the user home directory.
 
-| Repository Config   | Type | Default    | Description                                                    |
-| ------------------- | ---- | ---------- | -------------------------------------------------------------- |
-| requireChecks       | bool | true       | require checks to pass in order to merge                       |
-| requireApproval     | bool | true       | require pull request approval in order to merge                |
-| githubRepoOwner     | str  |            | name of the github owner (fetched from git remote config)      |
-| githubRepoName      | str  |            | name of the github repository (fetched from git remote config) |
-| githubRemote        | str  | origin     | github remote name to use                                      |
-| githubBranch        | str  | master     | github branch for pull request target                          |
-| githubHost          | str  | github.com | github host, can be updated for github enterprise usecase      |
-| mergeMethod         | str  | rebase     | merge method, valid values: [rebase, squash, merge]            |
+| Repository Config    | Type | Default    | Description                                                    |
+| -------------------- | ---- | ---------- | -------------------------------------------------------------- |
+| requireChecks        | bool | true       | require checks to pass in order to merge                       |
+| requireApproval      | bool | true       | require pull request approval in order to merge                |
+| githubRepoOwner      | str  |            | name of the github owner (fetched from git remote config)      |
+| githubRepoName       | str  |            | name of the github repository (fetched from git remote config) |
+| githubRemote         | str  | origin     | github remote name to use                                      |
+| githubBranch         | str  | master     | github branch for pull request target                          |
+| githubHost           | str  | github.com | github host, can be updated for github enterprise usecase      |
+| mergeMethod          | str  | rebase     | merge method, valid values: [rebase, squash, merge]            |
 
-| User Config         | Type | Default | Description                                                       |
-| ------------------- | ---- | ------- | ----------------------------------------------------------------- |
-| showPRLink          | bool | true    | show full pull request http link                                  |
-| logGitCommands      | bool | true    | logs all git commands to stdout                                   |
-| logGitHubCalls      | bool | true    | logs all github api calls to stdout                               |
-| statusBitsHeader    | bool | true    | show status bits type headers                                     |
-| statusBitsEmojis    | bool | true    | show status bits using fancy emojis                               |
-| createDraftPRs      | bool | false   | new pull requests are created as draft                            |
+| User Config          | Type | Default | Description                                                       |
+| -------------------- | ---- | ------- | ----------------------------------------------------------------- |
+| showPRLink           | bool | true    | show full pull request http link                                  |
+| logGitCommands       | bool | true    | logs all git commands to stdout                                   |
+| logGitHubCalls       | bool | true    | logs all github api calls to stdout                               |
+| statusBitsHeader     | bool | true    | show status bits type headers                                     |
+| statusBitsEmojis     | bool | true    | show status bits using fancy emojis                               |
+| createDraftPRs       | bool | false   | new pull requests are created as draft                            |
+| PreserveTitleAndBody | bool | false   | updating pull requests will not overwrite the pr title and body   |
 
 Happy Coding!
 -------------


### PR DESCRIPTION
When enabled the pull request title and body will not be overwritten
when a pull request is updated.
This also has the side effect of not outputing the stack into in the
pull request body. Ammending the current latest message is beyond the
scope of this change.

fixes: #236

---

**Stack**:
- #245
- #246
- #244
- #243
- #242 ⬅
- #239


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*