### PR TITLE
Fix critical bug introduced with #206

### DIFF
--- a/hook/install.go
+++ b/hook/install.go
@@ -11,15 +11,22 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const (
-	hookPath = "hooks/commit-msg"
-)
+var hookPath = "hooks/commit-msg"
 
 func InstallCommitHook(cfg *config.Config, gitcmd git.GitInterface) {
 	var rootdir string
 	err := gitcmd.Git("rev-parse --git-common-dir", &rootdir)
 	check(err)
 	rootdir = strings.TrimSpace(rootdir)
+
+	_, err = os.Stat(rootdir)
+	if os.IsNotExist(err) {
+		err = gitcmd.Git("rev-parse --show-toplevel", &rootdir)
+		check(err)
+		rootdir = strings.TrimSpace(rootdir)
+		hookPath = ".git/" + hookPath
+	}
+
 	err = os.Chdir(rootdir)
 	check(err)
 


### PR DESCRIPTION
Fix critical bug introduced with #206 that completely broke the spr experience starting from 0.8.3.
This fix should retain the intended feature introduced with #206, while falling back to the previously working root directory when `.git` directory is not found.

``` bash
$ git amend
> git rev-parse --show-toplevel
> git log --no-color origin/master..HEAD
> git rev-parse --git-common-dir
2022/06/05 14:15:00 chdir .git: no such file or directory
```

``` bash
$ git spr u
> git rev-parse --show-toplevel
> git fetch
> git rebase origin/master --autostash
> github fetch pull requests
> git branch --no-color
> git log --no-color origin/master..HEAD
> git rev-parse --git-common-dir
> git rebase origin/master -i --autosquash --autostash
> git log --no-color origin/master..HEAD
panic: unable to fetch local commits
 most likely this is an issue with missing commit-id in the commit body
 which is caused by the commit-msg hook not being installed propertly


goroutine 1 [running]:
github.com/ejoffe/spr/spr.(*stackediff).getLocalCommitStack(0xc0000b8d80)
        /Users/runner/work/spr/spr/spr/spr.go:332 +0x1a5
github.com/ejoffe/spr/spr.(*stackediff).UpdatePullRequests(0xc0000b8d80, {0x88deb0, 0xc0000a8000}, {0x0, 0x0, 0x0}, 0x0)
        /Users/runner/work/spr/spr/spr/spr.go:117 +0xe5
main.main.func3(0xc0000b8ea0)
        /Users/runner/work/spr/spr/cmd/spr/main.go:143 +0xdf
github.com/urfave/cli/v2.(*Command).Run(0xc0001630e0, 0xc0000badc0)
        /Users/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x64a
github.com/urfave/cli/v2.(*App).RunContext(0xc000164340, {0x88deb0, 0xc0000a8000}, {0xc0000bc000, 0x2, 0x2})
        /Users/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x81e
github.com/urfave/cli/v2.(*App).Run(...)
        /Users/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
        /Users/runner/work/spr/spr/cmd/spr/main.go:200 +0x1099
```