### PR TITLE
Disambiguate from getcord/spr which brew installs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Installation
 ### Brew
 ```bash
 > brew tap ejoffe/homebrew-tap
-> brew install spr
+> brew install ejoffe/tap/spr
 ```
 
 ### Apt


### PR DESCRIPTION
Unfortunately https://github.com/getcord/spr is installed when running `brew install spr`. I was only able to get the ejoffe version with the proposed change.