### PR TITLE
Update Apt install to work with file permissions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Installation
 
 ### Apt
 ```bash
-> echo "deb [trusted=yes] https://apt.fury.io/inigolabs/ /" > /etc/apt/sources.list.d/inigolabs.list
+> echo "deb [trusted=yes] https://apt.fury.io/inigolabs/ /" | sudo tee /etc/apt/sources.list.d/inigolabs.list
 > sudo apt update 
 > sudo apt install spr
 ```


### PR DESCRIPTION
As a non-root user, the existing command to update the apt sources list fails due to a lack of permissions. The updated command uses `sudo` to gain the permissions needed and `tee` to write the changes to the file.