### PR TITLE
git log: Pass --no-abbrev-commit

### DIFF
--- a/git/mockgit/mockgit.go
+++ b/git/mockgit/mockgit.go
@@ -65,7 +65,7 @@ func (m *Mock) ExpectFetch() {
 
 func (m *Mock) ExpectLogAndRespond(commits []*git.Commit) {
 	m.expect("git branch --no-color").respond("* master")
-	m.expect("git log --no-color origin/master..HEAD").commitRespond(commits)
+	m.expect("git log --no-abbrev-commit --no-color origin/master..HEAD").commitRespond(commits)
 }
 
 func (m *Mock) ExpectPushCommits(commits []*git.Commit) {

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -317,7 +317,7 @@ func (sd *stackediff) ProfilingSummary() {
 func (sd *stackediff) getLocalCommitStack() []git.Commit {
 	var commitLog string
 	targetBranch := githubclient.GetRemoteBranchName(sd.gitcmd, sd.config.Repo)
-	logCommand := fmt.Sprintf("log --no-color %s/%s..HEAD",
+	logCommand := fmt.Sprintf("log --no-abbrev-commit --no-color %s/%s..HEAD",
 		sd.config.Repo.GitHubRemote, targetBranch)
 	sd.mustgit(logCommand, &commitLog)
 	commits, valid := sd.parseLocalCommitStack(commitLog)


### PR DESCRIPTION
It's possible to set the `log.abbrevCommit` configuration,
which results in shortened commit hashes:

    log.abbrevCommit
        If true, makes git-log(1), git-show(1), and git-whatchanged(1) assume
        --abbrev-commit. You may override this option with --no-abbrev-commit.

If this configuration is set, spr does not recognize commit hashes
in `git log` because they're not 40 characters long.

This adds the --no-abbrev-commit option to spr's `git log` invocation
so that if a user has that configuration set, it doesn't break spr.
