### PR TITLE
Add support for PR templates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,10 @@ type RepoConfig struct {
 	RemoteBranches []string `yaml:"remoteBranches"`
 
 	MergeMethod string `default:"rebase" yaml:"mergeMethod"`
+
+	PRTemplatePath        string `yaml:"prTemplatePath"`
+	PRTemplateInsertStart string `yaml:"prTemplateInsertStart"`
+	PRTemplateInsertEnd   string `yaml:"prTemplateInsertEnd"`
 }
 
 type UserConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,14 +66,17 @@ func TestEmptyConfig(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	expect := &Config{
 		Repo: &RepoConfig{
-			GitHubRepoOwner: "",
-			GitHubRepoName:  "",
-			GitHubHost:      "github.com",
-			RequireChecks:   true,
-			RequireApproval: true,
-			GitHubRemote:    "origin",
-			GitHubBranch:    "master",
-			MergeMethod:     "rebase",
+			GitHubRepoOwner:       "",
+			GitHubRepoName:        "",
+			GitHubHost:            "github.com",
+			RequireChecks:         true,
+			RequireApproval:       true,
+			GitHubRemote:          "origin",
+			GitHubBranch:          "master",
+			MergeMethod:           "rebase",
+			PRTemplatePath:        "",
+			PRTemplateInsertStart: "",
+			PRTemplateInsertEnd:   "",
 		},
 		User: &UserConfig{
 			ShowPRLink:       true,

--- a/github/githubclient/gen/genclient/client.go
+++ b/github/githubclient/gen/genclient/client.go
@@ -16,55 +16,55 @@ type Client interface {
 		repoName string,
 	) (*PullRequestsResponse, error)
 
-	// AssignableUsers from github/githubclient/queries.graphql:39
+	// AssignableUsers from github/githubclient/queries.graphql:40
 	AssignableUsers(ctx context.Context,
 		repoOwner string,
 		repoName string,
 		endCursor *string,
 	) (*AssignableUsersResponse, error)
 
-	// CreatePullRequest from github/githubclient/queries.graphql:59
+	// CreatePullRequest from github/githubclient/queries.graphql:60
 	CreatePullRequest(ctx context.Context,
 		input CreatePullRequestInput,
 	) (*CreatePullRequestResponse, error)
 
-	// UpdatePullRequest from github/githubclient/queries.graphql:72
+	// UpdatePullRequest from github/githubclient/queries.graphql:73
 	UpdatePullRequest(ctx context.Context,
 		input UpdatePullRequestInput,
 	) (*UpdatePullRequestResponse, error)
 
-	// AddReviewers from github/githubclient/queries.graphql:84
+	// AddReviewers from github/githubclient/queries.graphql:85
 	AddReviewers(ctx context.Context,
 		input RequestReviewsInput,
 	) (*AddReviewersResponse, error)
 
-	// CommentPullRequest from github/githubclient/queries.graphql:96
+	// CommentPullRequest from github/githubclient/queries.graphql:97
 	CommentPullRequest(ctx context.Context,
 		input AddCommentInput,
 	) (*CommentPullRequestResponse, error)
 
-	// MergePullRequest from github/githubclient/queries.graphql:106
+	// MergePullRequest from github/githubclient/queries.graphql:107
 	MergePullRequest(ctx context.Context,
 		input MergePullRequestInput,
 	) (*MergePullRequestResponse, error)
 
-	// ClosePullRequest from github/githubclient/queries.graphql:118
+	// ClosePullRequest from github/githubclient/queries.graphql:119
 	ClosePullRequest(ctx context.Context,
 		input ClosePullRequestInput,
 	) (*ClosePullRequestResponse, error)
 
-	// StarCheck from github/githubclient/queries.graphql:130
+	// StarCheck from github/githubclient/queries.graphql:131
 	StarCheck(ctx context.Context,
 		after *string,
 	) (*StarCheckResponse, error)
 
-	// StarGetRepo from github/githubclient/queries.graphql:146
+	// StarGetRepo from github/githubclient/queries.graphql:147
 	StarGetRepo(ctx context.Context,
 		owner string,
 		name string,
 	) (*StarGetRepoResponse, error)
 
-	// StarAdd from github/githubclient/queries.graphql:155
+	// StarAdd from github/githubclient/queries.graphql:156
 	StarAdd(ctx context.Context,
 		input AddStarInput,
 	) (*StarAddResponse, error)

--- a/github/githubclient/gen/genclient/operations.go
+++ b/github/githubclient/gen/genclient/operations.go
@@ -21,6 +21,7 @@ type PullRequestsViewerPullRequestsNodes []*struct {
 	Id             string
 	Number         int
 	Title          string
+	Body           string
 	BaseRefName    string
 	HeadRefName    string
 	Mergeable      MergeableState
@@ -77,6 +78,7 @@ func (c *gqlclient) PullRequests(ctx context.Context,
 					id
 					number
 					title
+					body
 					baseRefName
 					headRefName
 					mergeable
@@ -159,7 +161,7 @@ type AssignableUsersResponse struct {
 	Repository *AssignableUsersRepository
 }
 
-// AssignableUsers from github/githubclient/queries.graphql:39
+// AssignableUsers from github/githubclient/queries.graphql:40
 func (c *gqlclient) AssignableUsers(ctx context.Context,
 	repoOwner string,
 	repoName string,
@@ -228,7 +230,7 @@ type CreatePullRequestResponse struct {
 	CreatePullRequest *CreatePullRequestCreatePullRequest
 }
 
-// CreatePullRequest from github/githubclient/queries.graphql:59
+// CreatePullRequest from github/githubclient/queries.graphql:60
 func (c *gqlclient) CreatePullRequest(ctx context.Context,
 	input CreatePullRequestInput,
 ) (*CreatePullRequestResponse, error) {
@@ -285,7 +287,7 @@ type UpdatePullRequestResponse struct {
 	UpdatePullRequest *UpdatePullRequestUpdatePullRequest
 }
 
-// UpdatePullRequest from github/githubclient/queries.graphql:72
+// UpdatePullRequest from github/githubclient/queries.graphql:73
 func (c *gqlclient) UpdatePullRequest(ctx context.Context,
 	input UpdatePullRequestInput,
 ) (*UpdatePullRequestResponse, error) {
@@ -341,7 +343,7 @@ type AddReviewersResponse struct {
 	RequestReviews *AddReviewersRequestReviews
 }
 
-// AddReviewers from github/githubclient/queries.graphql:84
+// AddReviewers from github/githubclient/queries.graphql:85
 func (c *gqlclient) AddReviewers(ctx context.Context,
 	input RequestReviewsInput,
 ) (*AddReviewersResponse, error) {
@@ -393,7 +395,7 @@ type CommentPullRequestResponse struct {
 	AddComment *CommentPullRequestAddComment
 }
 
-// CommentPullRequest from github/githubclient/queries.graphql:96
+// CommentPullRequest from github/githubclient/queries.graphql:97
 func (c *gqlclient) CommentPullRequest(ctx context.Context,
 	input AddCommentInput,
 ) (*CommentPullRequestResponse, error) {
@@ -447,7 +449,7 @@ type MergePullRequestResponse struct {
 	MergePullRequest *MergePullRequestMergePullRequest
 }
 
-// MergePullRequest from github/githubclient/queries.graphql:106
+// MergePullRequest from github/githubclient/queries.graphql:107
 func (c *gqlclient) MergePullRequest(ctx context.Context,
 	input MergePullRequestInput,
 ) (*MergePullRequestResponse, error) {
@@ -503,7 +505,7 @@ type ClosePullRequestResponse struct {
 	ClosePullRequest *ClosePullRequestClosePullRequest
 }
 
-// ClosePullRequest from github/githubclient/queries.graphql:118
+// ClosePullRequest from github/githubclient/queries.graphql:119
 func (c *gqlclient) ClosePullRequest(ctx context.Context,
 	input ClosePullRequestInput,
 ) (*ClosePullRequestResponse, error) {
@@ -569,7 +571,7 @@ type StarCheckResponse struct {
 	Viewer StarCheckViewer
 }
 
-// StarCheck from github/githubclient/queries.graphql:130
+// StarCheck from github/githubclient/queries.graphql:131
 func (c *gqlclient) StarCheck(ctx context.Context,
 	after *string,
 ) (*StarCheckResponse, error) {
@@ -627,7 +629,7 @@ type StarGetRepoResponse struct {
 	Repository *StarGetRepoRepository
 }
 
-// StarGetRepo from github/githubclient/queries.graphql:146
+// StarGetRepo from github/githubclient/queries.graphql:147
 func (c *gqlclient) StarGetRepo(ctx context.Context,
 	owner string,
 	name string,
@@ -679,7 +681,7 @@ type StarAddResponse struct {
 	AddStar *StarAddAddStar
 }
 
-// StarAdd from github/githubclient/queries.graphql:155
+// StarAdd from github/githubclient/queries.graphql:156
 func (c *gqlclient) StarAdd(ctx context.Context,
 	input AddStarInput,
 ) (*StarAddResponse, error) {

--- a/github/githubclient/queries.graphql
+++ b/github/githubclient/queries.graphql
@@ -9,6 +9,7 @@ query PullRequests(
 				id
 				number
 				title
+				body
 				baseRefName
 				headRefName
 				mergeable

--- a/github/pullrequest.go
+++ b/github/pullrequest.go
@@ -17,6 +17,7 @@ type PullRequest struct {
 	ToBranch   string
 	Commit     git.Commit
 	Title      string
+	Body       string
 
 	MergeStatus PullRequestMergeStatus
 	Merged      bool

--- a/readme.md
+++ b/readme.md
@@ -149,16 +149,20 @@ When the script is run for the first time two config files are created.
 Repository configuration is saved to .spr.yml in the repository base directory. 
 User specific configuration is saved to .spr.yml in the user home directory.
 
-| Repository Config    | Type | Default    | Description                                                    |
-| -------------------- | ---- | ---------- | -------------------------------------------------------------- |
-| requireChecks        | bool | true       | require checks to pass in order to merge                       |
-| requireApproval      | bool | true       | require pull request approval in order to merge                |
-| githubRepoOwner      | str  |            | name of the github owner (fetched from git remote config)      |
-| githubRepoName       | str  |            | name of the github repository (fetched from git remote config) |
-| githubRemote         | str  | origin     | github remote name to use                                      |
-| githubBranch         | str  | master     | github branch for pull request target                          |
-| githubHost           | str  | github.com | github host, can be updated for github enterprise use case     |
-| mergeMethod          | str  | rebase     | merge method, valid values: [rebase, squash, merge]            |
+| Repository Config     | Type | Default    | Description                                                                       |
+|-----------------------| ---- |------------|-----------------------------------------------------------------------------------|
+| requireChecks         | bool | true       | require checks to pass in order to merge                                          |
+| requireApproval       | bool | true       | require pull request approval in order to merge                                   |
+| githubRepoOwner       | str  |            | name of the github owner (fetched from git remote config)                         |
+| githubRepoName        | str  |            | name of the github repository (fetched from git remote config)                    |
+| githubRemote          | str  | origin     | github remote name to use                                                         |
+| githubBranch          | str  | master     | github branch for pull request target                                             |
+| githubHost            | str  | github.com | github host, can be updated for github enterprise use case                        |
+| mergeMethod           | str  | rebase     | merge method, valid values: [rebase, squash, merge]                               |
+| prTemplatePath        | str  |            | path to PR template (e.g. .github/PULL_REQUEST_TEMPLATE/pull_request_template.md) |
+| prTemplateInsertStart | str  |            | text to search for in PR template that determines body insert start location      |
+| prTemplateInsertEnd   | str  |            | text to search for in PR template that determines body insert end location        |
+
 
 | User Config          | Type | Default | Description                                                       |
 | -------------------- | ---- | ------- | ----------------------------------------------------------------- |


### PR DESCRIPTION
This change adds support for pull request templates and closes #266. It adds three new repo config settings:
* `prTemplatePath` - path to PR template (e.g. .github/PULL_REQUEST_TEMPLATE/pull_request_template.md)
* `prTemplateInsertStart` - text to search for in PR template that determines body insert start location
* `prTemplateInsertEnd` - text to search for in PR template that determines body insert end location

## Example
* Repo settings
```
prTemplatePath: .github/PULL_REQUEST_TEMPLATE/pull_request_template.md
prTemplateInsertStart: "# Description"
prTemplateInsertEnd: "# Checklist"
```
* PR template contents for `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`
```
# Related Issues
<add related issues here>

# Description
<add description here>

# Checklist
[ ] A checklist item
```
* Commits
  * add file 1
  * add file 2
* Resulting PR for first commit. The description section has been updated with commit message and spr generated stack info.
```
# Related Issues
<add related issues here>

# Description
This commit adds file 1

---

**Stack**:
- #1 ⬅
- #2


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

# Checklist
[ ] A checklist item
```
