### PR TITLE
Don't update stack for `merge` if `-c` is set

### DIFF
--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -162,14 +162,13 @@ VERSION: {{.Version}}
 				Name:  "merge",
 				Usage: "Merge all mergeable pull requests",
 				Action: func(c *cli.Context) error {
-
 					if c.IsSet("count") {
 						count := c.Uint("count")
 						stackedpr.MergePullRequests(ctx, &count)
 					} else {
 						stackedpr.MergePullRequests(ctx, nil)
+						stackedpr.UpdatePullRequests(ctx, nil, nil)
 					}
-					stackedpr.UpdatePullRequests(ctx, nil, nil)
 					return nil
 				},
 				Flags: []cli.Flag{


### PR DESCRIPTION
## What

Do not run `UpdatePullRequests` if `-c` is specified in the `merge` subcommand.

## Why

Suppose we have local commits: `c1`, `c2`, `c3`.
When run `git spr update -c 1`, PR will be created for `c1` only even though we do update the remote branch for `c2` and `c3`. This is expected behavior.

However, when running `git spr merge -c 1` subsequently, what happened was:

1. `c1` got merged
2. `c2` and `c3` branch are updated
3. PRs are created for `c2` and `c3`

When user add `-c 1` they may not want #3 to happen automatically. They may just want to merge the bottom PR and if they want to create new PRs for `c2` and `c3` they can do so with `git spr update`. This PR gives user more control by allowing only `merge` without `update / create PR`.

Note that we remove #2 and #3 altogether but perhaps we can add a flag to further distinguish them.