### PR TITLE
Tolerate custom format.pretty settings in user .gitconfig

### DIFF
--- a/git/mockgit/mockgit.go
+++ b/git/mockgit/mockgit.go
@@ -65,7 +65,7 @@ func (m *Mock) ExpectFetch() {
 
 func (m *Mock) ExpectLogAndRespond(commits []*git.Commit) {
 	m.expect("git branch --no-color").respond("* master")
-	m.expect("git log --no-color origin/master..HEAD").commitRespond(commits)
+	m.expect("git log --format=medium --no-color origin/master..HEAD").commitRespond(commits)
 }
 
 func (m *Mock) ExpectPushCommits(commits []*git.Commit) {

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -442,7 +442,7 @@ func (sd *stackediff) ProfilingSummary() {
 func (sd *stackediff) getLocalCommitStack() []git.Commit {
 	var commitLog string
 	targetBranch := githubclient.GetRemoteBranchName(sd.gitcmd, sd.config.Repo)
-	logCommand := fmt.Sprintf("log --no-color %s/%s..HEAD",
+	logCommand := fmt.Sprintf("log --format=medium --no-color %s/%s..HEAD",
 		sd.config.Repo.GitHubRemote, targetBranch)
 	sd.mustgit(logCommand, &commitLog)
 	commits, valid := sd.parseLocalCommitStack(commitLog)


### PR DESCRIPTION
parseLocalCommitStack assumes the commit log string conforms to --pretty=/--format=medium. If the user has a custom setting for format.pretty in .gitconfig (for example: oneline) , this assumption can break and spr reports:
"pull request stack is empty".

This commit changes the git log command to always specify --format=medium to avoid this issue.