### PR TITLE
Update PR descriptions after commit reordering

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -492,8 +492,7 @@ func addManualMergeNotice(body string) string {
 		"Do not merge manually using the UI - doing so may have unexpected results.*"
 }
 
-func (c *client) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface,
-	info *github.GitHubInfo, pr *github.PullRequest, commit git.Commit, prevCommit *git.Commit) {
+func (c *client) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface, pullRequests []*github.PullRequest, pr *github.PullRequest, commit git.Commit, prevCommit *git.Commit) {
 
 	if c.config.User.LogGitHubCalls {
 		fmt.Printf("> github update %d : %s\n", pr.Number, pr.Title)
@@ -508,7 +507,7 @@ func (c *client) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface,
 		Str("FromBranch", pr.FromBranch).Str("ToBranch", baseRefName).
 		Interface("PR", pr).Msg("UpdatePullRequest")
 
-	body := formatBody(commit, info.PullRequests)
+	body := formatBody(commit, pullRequests)
 	if c.config.Repo.PRTemplatePath != "" {
 		pullRequestTemplate, err := readPRTemplate(gitcmd, c.config.Repo.PRTemplatePath)
 		if err != nil {

--- a/github/interface.go
+++ b/github/interface.go
@@ -18,7 +18,7 @@ type GitHubInterface interface {
 	CreatePullRequest(ctx context.Context, gitcmd git.GitInterface, info *GitHubInfo, commit git.Commit, prevCommit *git.Commit) *PullRequest
 
 	// UpdatePullRequest updates a pull request with current commit
-	UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface, info *GitHubInfo, pr *PullRequest, commit git.Commit, prevCommit *git.Commit)
+	UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface, pullRequests []*PullRequest, pr *PullRequest, commit git.Commit, prevCommit *git.Commit)
 
 	// AddReviewers adds a reviewer to the given pull request
 	AddReviewers(ctx context.Context, pr *PullRequest, userIDs []string)

--- a/github/mockclient/mockclient.go
+++ b/github/mockclient/mockclient.go
@@ -81,8 +81,7 @@ func (c *MockClient) CreatePullRequest(ctx context.Context, gitcmd git.GitInterf
 	}
 }
 
-func (c *MockClient) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface, info *github.GitHubInfo,
-	pr *github.PullRequest, commit git.Commit, prevCommit *git.Commit) {
+func (c *MockClient) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface, pullRequests []*github.PullRequest, pr *github.PullRequest, commit git.Commit, prevCommit *git.Commit) {
 	fmt.Printf("HUB: UpdatePullRequest\n")
 	c.verifyExpectation(expectation{
 		op:     updatePullRequestOP,

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -150,7 +150,7 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context, reviewers []string
 		for i := range githubInfo.PullRequests {
 			go func(i int) {
 				pr := githubInfo.PullRequests[i]
-				sd.github.UpdatePullRequest(ctx, sd.gitcmd, githubInfo, pr, pr.Commit, nil)
+				sd.github.UpdatePullRequest(ctx, sd.gitcmd, githubInfo.PullRequests, pr, pr.Commit, nil)
 				wg.Done()
 			}(i)
 		}
@@ -224,7 +224,7 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context, reviewers []string
 	for i := range updateQueue {
 		go func(i int) {
 			pr := updateQueue[i]
-			sd.github.UpdatePullRequest(ctx, sd.gitcmd, githubInfo, pr.pr, pr.commit, pr.prevCommit)
+			sd.github.UpdatePullRequest(ctx, sd.gitcmd, githubInfo.PullRequests, pr.pr, pr.commit, pr.prevCommit)
 			wg.Done()
 		}(i)
 	}
@@ -295,7 +295,7 @@ func (sd *stackediff) MergePullRequests(ctx context.Context, count *uint) {
 	prToMerge := githubInfo.PullRequests[prIndex]
 
 	// Update the base of the merging pr to target branch
-	sd.github.UpdatePullRequest(ctx, sd.gitcmd, githubInfo, prToMerge, prToMerge.Commit, nil)
+	sd.github.UpdatePullRequest(ctx, sd.gitcmd, githubInfo.PullRequests, prToMerge, prToMerge.Commit, nil)
 	sd.profiletimer.Step("MergePullRequests::update pr base")
 
 	// Merge pull request


### PR DESCRIPTION
Fixes #277

I'm not sure how useful this is. It seems to work but I have next to zero experience w/golang. I also wasn't sure if there was a good facility in place to test this... I looked at the existing `TestSPRReorderCommit` but it seems the mock github client isn't really set up to verify on the passed in `github.GItHubInfo`