### PR TITLE
remove MaybeStar call from main.go

### DIFF
--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -116,7 +116,6 @@ VERSION: {{.Version}}
 				cfg.User.LogGitCommands = true
 				cfg.User.LogGitHubCalls = true
 			}
-			client.MaybeStar(ctx, cfg)
 			return nil
 		},
 		Commands: []*cli.Command{


### PR DESCRIPTION
## Problem
when performing work, contributing to an open source project, or any other time the user is using `spr` they obviously don't want to be interrupted. It is worse than this interruption is for what is effectively spamming a meaningless metric.

## Solution

Remove the call that generates this spam. Future work can delete the code entirely.