### PR TITLE
Address deprecation warning on goreleaser's --rm-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 
 bin:
-	goreleaser --snapshot --skip-publish --rm-dist
+	goreleaser --snapshot --skip-publish --clean
 


### PR DESCRIPTION
When running `make` I see this deprecation warning:

```
Flag --rm-dist has been deprecated, please use --clean instead
```

I run this version of `goreleaser`:

```
$ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.19.1
GitCommit:     6b46a1a6aa51e45bd281d55b6e5a2315ee82f643
GitTreeState:  false
BuildDate:     2023-06-29T12:55:30Z
BuiltBy:       goreleaser
GoVersion:     go1.20.5
Compiler:      gc
ModuleSum:     h1:MVAFo62jkj6/JflxruefIwfFTqNTeNtkT12Hab1o2Lk=
Platform:      linux/amd64
```