### PR TITLE
Address `archives.replacements` being removed from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,13 +32,14 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=gorelease
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: macos
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- if eq .Os "Darwin" }}macos_
+      {{- else }}{{- tolower .Os }}_{{end}}
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}
+      {{ if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
     - goos: windows
       format: zip
@@ -55,7 +56,7 @@ changelog:
 brews:
   - 
     name: spr
-    tap:
+    repository:
       owner: ejoffe
       name: homebrew-tap
     homepage: https://github.com/ejoffe/spr


### PR DESCRIPTION
The `archives.replacement` structure in the `.goreleaser.yml` was
deprecated and recently removed.

This change addresses this problem by using the proposed solution
from https://goreleaser.com/deprecations/#archivesreplacements with a
slight modification. Instead of title-cased replacements of the
operating system we want it to be all lowercase because that is how the
old replacement items looked like:

```yaml
archives:
  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
    replacements:
      darwin: macos
      linux: linux
      windows: windows
      386: i386
      amd64: x86_64      
```

Hence the new `name_template` uses as lower-cased operating system name
(`{{- tolower .Os }}`) and a special handling for turning `darwin` into
`macos` as well as the architecture handling.

Then another deprecation warning came up:

```
DEPRECATED: `brews.tap` should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
```

I addressed this with a simply `tap` -> `repository` replacement.

Fixes #339
