### PR TITLE
fix: WIP commit panic in formatStackMarkdown

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -456,7 +456,9 @@ func sortPullRequestsByLocalCommitOrder(pullRequests []*github.PullRequest, loca
 
 	var sortedPullRequests []*github.PullRequest
 	for _, commit := range localCommits {
-		sortedPullRequests = append(sortedPullRequests, pullRequestMap[commit.CommitID])
+		if !commit.WIP {
+			sortedPullRequests = append(sortedPullRequests, pullRequestMap[commit.CommitID])
+		}
 	}
 	return sortedPullRequests
 }


### PR DESCRIPTION
Fixes the panic below:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1049bfa50]

goroutine 52 [running]:
github.com/ejoffe/spr/github/githubclient.formatStackMarkdown({{0x140001c636d, 0x8}, {0x140001c61d0, 0x28}, {0x140001c6252, 0x23}, {0x140001e4001, 0xce}, 0x0}, {0x14000281e40, ...})
	/Users/USER/go/src/github.com/ejoffe/spr/github/githubclient/client.go:399 +0x60
github.com/ejoffe/spr/github/githubclient.formatBody({{0x140001c636d, 0x8}, {0x140001c61d0, 0x28}, {0x140001c6252, 0x23}, {0x140001e4001, 0xce}, 0x0}, {0x14000281e40?, ...})
	/Users/USER/go/src/github.com/ejoffe/spr/github/githubclient/client.go:424 +0xf0
github.com/ejoffe/spr/github/githubclient.(*client).UpdatePullRequest(0x140000aaa80, {0x104b9c598, 0x1400009c010}, {0x104b9c720, 0x140000aaa38}, {0x14000281e40, 0x7, 0x8}, 0x140002d52c0, {{0x140001c636d, ...}, ...}, ...)
	/Users/USER/go/src/github.com/ejoffe/spr/github/githubclient/client.go:510 +0x3d4
github.com/ejoffe/spr/spr.(*stackediff).UpdatePullRequests.func2(0x0?)
	/Users/USER/go/src/github.com/ejoffe/spr/spr/spr.go:229 +0xcc
created by github.com/ejoffe/spr/spr.(*stackediff).UpdatePullRequests
	/Users/USER/go/src/github.com/ejoffe/spr/spr/spr.go:227 +0xf94
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1049bfa50]
```