### PR TITLE
fix: support large repos by fetching only user's pull requests

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -185,7 +185,7 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 	targetBranch := c.config.Internal.GitHubBranch
 	localCommitStack := git.GetLocalCommitStack(c.config, gitcmd)
 
-	pullRequests := matchPullRequestStack(c.config.Repo, targetBranch, localCommitStack, resp.Repository.PullRequests)
+	pullRequests := matchPullRequestStack(c.config.Repo, targetBranch, localCommitStack, resp.Viewer.PullRequests)
 	for _, pr := range pullRequests {
 		if pr.Ready(c.config) {
 			pr.MergeStatus.Stacked = true
@@ -209,7 +209,7 @@ func matchPullRequestStack(
 	repoConfig *config.RepoConfig,
 	targetBranch string,
 	localCommitStack []git.Commit,
-	allPullRequests genclient.PullRequestsRepositoryPullRequests) []*github.PullRequest {
+	allPullRequests genclient.PullRequestsViewerPullRequests) []*github.PullRequest {
 
 	if len(localCommitStack) == 0 || allPullRequests.Nodes == nil {
 		return []*github.PullRequest{}

--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -15,19 +15,19 @@ func TestMatchPullRequestStack(t *testing.T) {
 	tests := []struct {
 		name    string
 		commits []git.Commit
-		prs     genclient.PullRequestsRepositoryPullRequests
+		prs     genclient.PullRequestsViewerPullRequests
 		expect  []*github.PullRequest
 	}{
 		{
 			name:    "Empty",
 			commits: []git.Commit{},
-			prs:     genclient.PullRequestsRepositoryPullRequests{},
+			prs:     genclient.PullRequestsViewerPullRequests{},
 			expect:  []*github.PullRequest{},
 		},
 		{
 			name:    "FirstCommit",
 			commits: []git.Commit{{CommitID: "00000001"}},
-			prs:     genclient.PullRequestsRepositoryPullRequests{},
+			prs:     genclient.PullRequestsViewerPullRequests{},
 			expect:  []*github.PullRequest{},
 		},
 		{
@@ -36,16 +36,16 @@ func TestMatchPullRequestStack(t *testing.T) {
 				{CommitID: "00000001"},
 				{CommitID: "00000002"},
 			},
-			prs: genclient.PullRequestsRepositoryPullRequests{
-				Nodes: &genclient.PullRequestsRepositoryPullRequestsNodes{
+			prs: genclient.PullRequestsViewerPullRequests{
+				Nodes: &genclient.PullRequestsViewerPullRequestsNodes{
 					{
 						Id:          "1",
 						HeadRefName: "spr/master/00000001",
 						BaseRefName: "master",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "1"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "1"},
 								},
 							},
 						},
@@ -74,16 +74,16 @@ func TestMatchPullRequestStack(t *testing.T) {
 				{CommitID: "00000002"},
 				{CommitID: "00000003"},
 			},
-			prs: genclient.PullRequestsRepositoryPullRequests{
-				Nodes: &genclient.PullRequestsRepositoryPullRequestsNodes{
+			prs: genclient.PullRequestsViewerPullRequests{
+				Nodes: &genclient.PullRequestsViewerPullRequestsNodes{
 					{
 						Id:          "1",
 						HeadRefName: "spr/master/00000001",
 						BaseRefName: "master",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "1"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "1"},
 								},
 							},
 						},
@@ -92,10 +92,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "2",
 						HeadRefName: "spr/master/00000002",
 						BaseRefName: "spr/master/00000001",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "2"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "2"},
 								},
 							},
 						},
@@ -132,16 +132,16 @@ func TestMatchPullRequestStack(t *testing.T) {
 		{
 			name:    "RemoveOnlyCommit",
 			commits: []git.Commit{},
-			prs: genclient.PullRequestsRepositoryPullRequests{
-				Nodes: &genclient.PullRequestsRepositoryPullRequestsNodes{
+			prs: genclient.PullRequestsViewerPullRequests{
+				Nodes: &genclient.PullRequestsViewerPullRequestsNodes{
 					{
 						Id:          "1",
 						HeadRefName: "spr/master/00000001",
 						BaseRefName: "master",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "1"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "1"},
 								},
 							},
 						},
@@ -156,16 +156,16 @@ func TestMatchPullRequestStack(t *testing.T) {
 				{CommitID: "00000001"},
 				{CommitID: "00000002"},
 			},
-			prs: genclient.PullRequestsRepositoryPullRequests{
-				Nodes: &genclient.PullRequestsRepositoryPullRequestsNodes{
+			prs: genclient.PullRequestsViewerPullRequests{
+				Nodes: &genclient.PullRequestsViewerPullRequestsNodes{
 					{
 						Id:          "1",
 						HeadRefName: "spr/master/00000001",
 						BaseRefName: "master",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "1"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "1"},
 								},
 							},
 						},
@@ -174,10 +174,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "3",
 						HeadRefName: "spr/master/00000003",
 						BaseRefName: "spr/master/00000002",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "2"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "2"},
 								},
 							},
 						},
@@ -186,10 +186,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "2",
 						HeadRefName: "spr/master/00000002",
 						BaseRefName: "spr/master/00000001",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "2"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "2"},
 								},
 							},
 						},
@@ -229,16 +229,16 @@ func TestMatchPullRequestStack(t *testing.T) {
 				{CommitID: "00000001"},
 				{CommitID: "00000003"},
 			},
-			prs: genclient.PullRequestsRepositoryPullRequests{
-				Nodes: &genclient.PullRequestsRepositoryPullRequestsNodes{
+			prs: genclient.PullRequestsViewerPullRequests{
+				Nodes: &genclient.PullRequestsViewerPullRequestsNodes{
 					{
 						Id:          "1",
 						HeadRefName: "spr/master/00000001",
 						BaseRefName: "master",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "1"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "1"},
 								},
 							},
 						},
@@ -247,10 +247,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "2",
 						HeadRefName: "spr/master/00000002",
 						BaseRefName: "spr/master/00000001",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "2"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "2"},
 								},
 							},
 						},
@@ -259,10 +259,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "3",
 						HeadRefName: "spr/master/00000003",
 						BaseRefName: "spr/master/00000002",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "3"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "3"},
 								},
 							},
 						},
@@ -314,16 +314,16 @@ func TestMatchPullRequestStack(t *testing.T) {
 				{CommitID: "00000002"},
 				{CommitID: "00000003"},
 			},
-			prs: genclient.PullRequestsRepositoryPullRequests{
-				Nodes: &genclient.PullRequestsRepositoryPullRequestsNodes{
+			prs: genclient.PullRequestsViewerPullRequests{
+				Nodes: &genclient.PullRequestsViewerPullRequestsNodes{
 					{
 						Id:          "1",
 						HeadRefName: "spr/master/00000001",
 						BaseRefName: "master",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "1"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "1"},
 								},
 							},
 						},
@@ -332,10 +332,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "2",
 						HeadRefName: "spr/master/00000002",
 						BaseRefName: "spr/master/00000001",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "2"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "2"},
 								},
 							},
 						},
@@ -344,10 +344,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 						Id:          "3",
 						HeadRefName: "spr/master/00000003",
 						BaseRefName: "spr/master/00000002",
-						Commits: genclient.PullRequestsRepositoryPullRequestsNodesCommits{
-							Nodes: &genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodes{
+						Commits: genclient.PullRequestsViewerPullRequestsNodesCommits{
+							Nodes: &genclient.PullRequestsViewerPullRequestsNodesCommitsNodes{
 								{
-									genclient.PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit{Oid: "3"},
+									genclient.PullRequestsViewerPullRequestsNodesCommitsNodesCommit{Oid: "3"},
 								},
 							},
 						},

--- a/github/githubclient/gen/genclient/operations.go
+++ b/github/githubclient/gen/genclient/operations.go
@@ -9,19 +9,15 @@ import (
 )
 
 type PullRequestsViewer struct {
-	Login string
+	Login        string
+	PullRequests PullRequestsViewerPullRequests
 }
 
-type PullRequestsRepository struct {
-	Id           string
-	PullRequests PullRequestsRepositoryPullRequests
+type PullRequestsViewerPullRequests struct {
+	Nodes *PullRequestsViewerPullRequestsNodes
 }
 
-type PullRequestsRepositoryPullRequests struct {
-	Nodes *PullRequestsRepositoryPullRequestsNodes
-}
-
-type PullRequestsRepositoryPullRequestsNodes []*struct {
+type PullRequestsViewerPullRequestsNodes []*struct {
 	Id             string
 	Number         int
 	Title          string
@@ -30,31 +26,35 @@ type PullRequestsRepositoryPullRequestsNodes []*struct {
 	HeadRefName    string
 	Mergeable      MergeableState
 	ReviewDecision *PullRequestReviewDecision
-	Repository     PullRequestsRepositoryPullRequestsNodesRepository
-	Commits        PullRequestsRepositoryPullRequestsNodesCommits
+	Repository     PullRequestsViewerPullRequestsNodesRepository
+	Commits        PullRequestsViewerPullRequestsNodesCommits
 }
 
-type PullRequestsRepositoryPullRequestsNodesRepository struct {
+type PullRequestsViewerPullRequestsNodesRepository struct {
 	Id string
 }
 
-type PullRequestsRepositoryPullRequestsNodesCommits struct {
-	Nodes *PullRequestsRepositoryPullRequestsNodesCommitsNodes
+type PullRequestsViewerPullRequestsNodesCommits struct {
+	Nodes *PullRequestsViewerPullRequestsNodesCommitsNodes
 }
 
-type PullRequestsRepositoryPullRequestsNodesCommitsNodes []*struct {
-	Commit PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit
+type PullRequestsViewerPullRequestsNodesCommitsNodes []*struct {
+	Commit PullRequestsViewerPullRequestsNodesCommitsNodesCommit
 }
 
-type PullRequestsRepositoryPullRequestsNodesCommitsNodesCommit struct {
+type PullRequestsViewerPullRequestsNodesCommitsNodesCommit struct {
 	Oid               string
 	MessageHeadline   string
 	MessageBody       string
-	StatusCheckRollup *PullRequestsRepositoryPullRequestsNodesCommitsNodesCommitStatusCheckRollup
+	StatusCheckRollup *PullRequestsViewerPullRequestsNodesCommitsNodesCommitStatusCheckRollup
 }
 
-type PullRequestsRepositoryPullRequestsNodesCommitsNodesCommitStatusCheckRollup struct {
+type PullRequestsViewerPullRequestsNodesCommitsNodesCommitStatusCheckRollup struct {
 	State StatusState
+}
+
+type PullRequestsRepository struct {
+	Id string
 }
 
 // PullRequestsResponse response type for PullRequests
@@ -73,9 +73,6 @@ func (c *gqlclient) PullRequests(ctx context.Context,
 	query PullRequests($repo_owner : String!, $repo_name : String!) {
 		viewer {
 			login
-		}
-		repository(owner: $repo_owner, name: $repo_name) {
-			id
 			pullRequests(first: 100, states: [OPEN]) {
 				nodes {
 					id
@@ -103,6 +100,9 @@ func (c *gqlclient) PullRequests(ctx context.Context,
 					}
 				}
 			}
+		}
+		repository(owner: $repo_owner, name: $repo_name) {
+			id
 		}
 	}`
 

--- a/github/githubclient/queries.graphql
+++ b/github/githubclient/queries.graphql
@@ -4,9 +4,6 @@ query PullRequests(
 ){
 	viewer {
 		login
-	}
-	repository(owner:$repo_owner, name:$repo_name) {
-		id
 		pullRequests(first:100, states:[OPEN]) {
 			nodes {
 				id
@@ -34,6 +31,9 @@ query PullRequests(
 				}
 			}
 		}
+	}
+	repository(owner:$repo_owner, name:$repo_name) {
+		id
 	}
 }
 


### PR DESCRIPTION
Previously, all pull requests for the current repo were queried, with a limit of 100. This means spr would not function for any repos with over 100 open pull requests, which is fairly common for larger repos. Instead, query for only the current user's pull requests.

Fixes #319 