### PR TITLE
Check goreleaser config in CI github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
     - name: Test
       working-directory: ./
       run: go test -race -coverprofile=./coverage.txt -covermode=atomic ./...
-    
+
+    - name: Check goreleaser file
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: check
+
     #- name: Upload coverage
     #  uses: codecov/codecov-action@v2
     #  with:


### PR DESCRIPTION
This adds a check to the CI workflow file to check for the sanity of the `.goreleaser.yml` file by running `goreleaser check`.