### PR TITLE
Get rid of space at the end of archive name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,14 +32,7 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=gorelease
 archives:
-  - name_template: >-
-      {{ .ProjectName }}_
-      {{- if eq .Os "Darwin" }}macos_
-      {{- else }}{{- tolower .Os }}_{{end}}
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{ if .Arm }}v{{ .Arm }}{{ end }}
+  - name_template: '{{ .ProjectName }}_{{- if eq .Os "Darwin" }}macos_{{- else }}{{- tolower .Os }}_{{end}}{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
For some reason the `make` produced these archives:

```
  • archives
    • creating                                       archive=dist/spr_linux_x86_64 .tar.gz
    • creating                                       archive=dist/spr_linux_arm64 .tar.gz
    • creating                                       archive=dist/spr_windows_x86_64 .zip
    • creating                                       archive=dist/spr_windows_arm64 .zip
    • creating                                       archive=dist/spr_darwin_arm64 .tar.gz
    • creating                                       archive=dist/spr_linux_i386 .tar.gz
    • creating                                       archive=dist/spr_windows_i386 .zip
    • creating                                       archive=dist/spr_darwin_x86_64 .tar.gz
```

Notice the space at the end. I guess it has to do with folding newlines into whitespaces but for the sake of a quick fix I just reformatted the `>-` YAML multi-line string as a regular string in one line and now the problem is gone.

This addresses https://github.com/ejoffe/spr/pull/344#issuecomment-1627388084

Fixup for #340