### PR TITLE
Respect MergeQueue bool flag when querying github PRs

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -179,7 +179,8 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 	}
 	resp, err := c.api.PullRequests(ctx,
 		c.config.Repo.GitHubRepoOwner,
-		c.config.Repo.GitHubRepoName)
+		c.config.Repo.GitHubRepoName,
+        c.config.Repo.MergeQueue)
 	check(err)
 
 	targetBranch := c.config.Repo.GitHubBranch

--- a/github/githubclient/gen/genclient/client.go
+++ b/github/githubclient/gen/genclient/client.go
@@ -14,6 +14,7 @@ type Client interface {
 	PullRequests(ctx context.Context,
 		repoOwner string,
 		repoName string,
+        useMergeQueue bool,
 	) (*PullRequestsResponse, error)
 
 	// AssignableUsers from github/githubclient/queries.graphql:43

--- a/github/githubclient/gen/genclient/operations.go
+++ b/github/githubclient/gen/genclient/operations.go
@@ -72,6 +72,7 @@ type PullRequestsResponse struct {
 func (c *gqlclient) PullRequests(ctx context.Context,
 	repoOwner string,
 	repoName string,
+    useMergeQueue bool,
 ) (*PullRequestsResponse, error) {
 
 	var pullRequestsOperation string = `
@@ -91,9 +92,17 @@ func (c *gqlclient) PullRequests(ctx context.Context,
 				repository {
 					id
 				}
+`
+
+	if useMergeQueue {
+		pullRequestsOperation += `
 				mergeQueueEntry {
 					id
 				}
+`
+	}
+
+	pullRequestsOperation += `
 				commits(first: 100) {
 					nodes {
 						commit {
@@ -114,7 +123,6 @@ func (c *gqlclient) PullRequests(ctx context.Context,
 	}
 }
 `
-
 	gqlreq := &client.GQLRequest{
 		OperationName: "PullRequests",
 		Query:         pullRequestsOperation,


### PR DESCRIPTION
Disclaimer: I have never written Go code before. 

For enterprise clients on a github version < 3.11 MergeQueue support isn't implemented. As a result

```
mergeQueueEntry {
    id
}
```

isn't valid inside of the pull request query.

This is logically the correct way to do this, but I understand two of these files are generated and I shouldn't edit them, however I'm unsure of how to actually generate `client.go` and `operations.go`.

If someone can point me in the right direction I can update the PR to generate `client.go` and `operations.go` correctly

Closes #356 