### PR TITLE
adds option to show pr titles in stack description

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ type RepoConfig struct {
 	MergeCheck string `yaml:"mergeCheck,omitempty"`
 
 	ForceFetchTags bool `default:"false" yaml:"forceFetchTags"`
+
+	ShowPrTitlesInStack bool `default:"false" yaml:"showPrTitlesInStack"`
 }
 
 type UserConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func TestDefaultConfig(t *testing.T) {
 			PRTemplatePath:        "",
 			PRTemplateInsertStart: "",
 			PRTemplateInsertEnd:   "",
+			ShowPrTitlesInStack:   false,
 		},
 		User: &UserConfig{
 			ShowPRLink:       true,

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,7 @@ User specific configuration is saved to .spr.yml in the user home directory.
 | mergeCheck              | str  |            | enforce a pre-merge check using 'git spr check' |
 | forceFetchTags          | bool | false      | also fetch tags when running 'git spr update' |
 | branchNameIncludeTarget | bool | false      | include target branch name in pull request branch name |
+| showPrTitlesInStack     | bool | false      | show PR titles in stack description within pull request body |
 
 
 | User Config          | Type | Default | Description                                                     |


### PR DESCRIPTION
## Summary
This PR adds a new repository config field that toggles displaying each PR's title in the PR body's stack description like so:

```
**Stack**:
- Title B #2 ⬅
- Title A #1
```

This is helpful for github enterprise instances that are not on the latest version where PR titles automatically populate alongside PR numbers.

The field is named `showPrTitlesInStack` and defaults to false.

I've added respective tests to maintain coverage with the added functionality in `github/githubclient/client.go` and have built and installed this binary locally to dogfood the new behavior.