### PR TITLE
Fix getRepoDetailsFromRemote failing to detect repo owners that include dashes

### DIFF
--- a/config/config_parser/config_parser_test.go
+++ b/config/config_parser/config_parser_test.go
@@ -20,21 +20,30 @@ func TestGetRepoDetailsFromRemote(t *testing.T) {
 		{"origin  https://github.com/r2/d2.git (push)", "github.com", "r2", "d2", true},
 		{"origin  https://github.com/r2/d2.git (fetch)", "", "", "", false},
 		{"origin  https://github.com/r2/d2 (push)", "github.com", "r2", "d2", true},
+		{"origin  https://github.com/r-2/d-2 (push)", "github.com", "r-2", "d-2", true},
 
 		{"origin  ssh://git@github.com/r2/d2.git (push)", "github.com", "r2", "d2", true},
 		{"origin  ssh://git@github.com/r2/d2.git (fetch)", "", "", "", false},
 		{"origin  ssh://git@github.com/r2/d2 (push)", "github.com", "r2", "d2", true},
+		{"origin  ssh://git@github.com/r-2/d-2 (push)", "github.com", "r-2", "d-2", true},
 
 		{"origin  git@github.com:r2/d2.git (push)", "github.com", "r2", "d2", true},
 		{"origin  git@github.com:r2/d2.git (fetch)", "", "", "", false},
 		{"origin  git@github.com:r2/d2 (push)", "github.com", "r2", "d2", true},
+		{"origin  git@github.com:r-2/d-2 (push)", "github.com", "r-2", "d-2", true},
 
 		{"origin  git@gh.enterprise.com:r2/d2.git (push)", "gh.enterprise.com", "r2", "d2", true},
 		{"origin  git@gh.enterprise.com:r2/d2.git (fetch)", "", "", "", false},
 		{"origin  git@gh.enterprise.com:r2/d2 (push)", "gh.enterprise.com", "r2", "d2", true},
+		{"origin  git@gh.enterprise.com:r-2/d-2 (push)", "gh.enterprise.com", "r-2", "d-2", true},
 
 		{"origin  https://github.com/r2/d2-a.git (push)", "github.com", "r2", "d2-a", true},
+		{"origin  https://github.com/r-2/d2-a.git (push)", "github.com", "r-2", "d2-a", true},
 		{"origin  https://github.com/r2/d2_a.git (push)", "github.com", "r2", "d2_a", true},
+		{"origin  https://github.com/r-2/d2_a.git (push)", "github.com", "r-2", "d2_a", true},
+
+		// GitHub names are case-sensitive
+		{"origin  https://github.com/R2/D2.git (push)", "github.com", "R2", "D2", true},
 	}
 	for i, testCase := range testCases {
 		t.Logf("Testing %v %q", i, testCase.remote)

--- a/config/config_parser/remote_source.go
+++ b/config/config_parser/remote_source.go
@@ -45,7 +45,7 @@ func getRepoDetailsFromRemote(remote string) (string, string, string, bool) {
 	userFormat := `(git@)?`
 	// "/" is expected in "http://" or "ssh://" protocol, when no protocol given
 	// it should be ":"
-	repoFormat := `(?P<githubHost>[a-z0-9._\-]+)(/|:)(?P<repoOwner>\w+)/(?P<repoName>[\w-]+)`
+	repoFormat := `(?P<githubHost>[a-z0-9._\-]+)(/|:)(?P<repoOwner>[\w-]+)/(?P<repoName>[\w-]+)`
 	// This is neither required in https access nor in ssh one
 	suffixFormat := `(.git)?`
 	regexFormat := fmt.Sprintf(`^origin\s+%s%s%s%s \(push\)`,


### PR DESCRIPTION
Fixes organization names with dashes not being properly detected by `getRepoDetailsFromRemote`. I've also added a few more test cases just to be sure.