### PR TITLE
update gh login instructions after gh CLI storage update

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -123,7 +123,7 @@ No GitHub OAuth token found! You can either create one
 at https://%s/settings/tokens and set the GITHUB_TOKEN environment variable,
 or use the official "gh" CLI (https://cli.github.com) config to log in:
 
-	$ gh auth login
+	$ gh auth login --insecure-storage
 
 Alternatively, configure a token manually in ~/.config/hub:
 


### PR DESCRIPTION
As shared [in this comment](https://github.com/ejoffe/spr/issues/335#issuecomment-1968400630), gh cli has changed the default behavior of how github auth tokens are saved. This change makes spr no longer able to read github auth tokens and has caused myself and others confusion when instructions say to run `gh auth login` but still see spr not be able to find the token. 

This change updates the instructions to avoid this confusion. I do understand that suggesting to users to use insecure storage may not be ideal and a different solution may be preferred. Whatever solution it is, I believe it's better then today where users of spr receive these help docs, try them, and do not see success.