### PR TITLE
Fix status check not working for PRs without any status checks

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -271,13 +271,15 @@ func matchPullRequestStack(
 				Body:       commit.MessageBody,
 			}
 
-			checkStatus := github.CheckStatusFail
+			checkStatus := github.CheckStatusPass
 			if commit.StatusCheckRollup != nil {
 				switch commit.StatusCheckRollup.State {
 				case "SUCCESS":
 					checkStatus = github.CheckStatusPass
 				case "PENDING":
 					checkStatus = github.CheckStatusPending
+				default:
+					checkStatus = github.CheckStatusFail
 				}
 			}
 

--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -61,7 +61,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						{CommitID: "2", CommitHash: "2", Body: "commit-id:2"},
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},
@@ -122,7 +122,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						{CommitID: "2", CommitHash: "2", Body: "commit-id:2"},
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 				{
@@ -138,7 +138,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						{CommitID: "3", CommitHash: "3", Body: "commit-id:3"},
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},
@@ -187,7 +187,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "1",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},
@@ -237,7 +237,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "1",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 				{
@@ -249,7 +249,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "2",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},
@@ -331,7 +331,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "1",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 				{
@@ -343,7 +343,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "2",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},
@@ -404,7 +404,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "1",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 				{
@@ -416,7 +416,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "2",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 				{
@@ -428,7 +428,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "3",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},
@@ -489,7 +489,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "1",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 
@@ -502,7 +502,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "2",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 				{
@@ -514,7 +514,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 						CommitHash: "3",
 					},
 					MergeStatus: github.PullRequestMergeStatus{
-						ChecksPass: github.CheckStatusFail,
+						ChecksPass: github.CheckStatusPass,
 					},
 				},
 			},


### PR DESCRIPTION
The Github GraphQL response returns null for the StatusCheckRollup object if there are no status checks at all. In that case, this should be a pass.

From my understanding, spr gets the state of the PullRequest with a graphql query like the following:

```sh
gh api graphql -f query='
  query PullRequest($repo_owner: String!, $repo_name: String!, $pr_number: Int!) {
    viewer {
      login
    }
    repository(owner: $repo_owner, name: $repo_name) {
      pullRequest(number: $pr_number) {
        id
        number
        title
        body
        baseRefName
        headRefName
        mergeable
        reviewDecision
        repository {
          id
        }
        commits(first: 100) {
          nodes {
            commit {
              oid
              messageHeadline
              messageBody
              statusCheckRollup {
                state
              }
            }
          }
        }
      }
    }
  }' -f repo_owner='myrepo' -f repo_name='myrepo' -f pr_number=123
```

On the repository I am working on, this would give a response with a `statusCheckRollup: null`:

```json
{
  "data": {
    "viewer": {
      "login": "Skipants"
    },
    "repository": {
      "pullRequest": {
        "id": "PR_fakeid123",
        "number": 123,
        "title": "My Cool PR",
        "body": "My Cool PR Stack\n\n---\n\n**Stack**:\n- #456\n- #123 ⬅\n\n\n⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing s
o may have unexpected results.*",
        "baseRefName": "master",
        "headRefName": "spr/master/abc123",
        "mergeable": "MERGEABLE",
        "reviewDecision": "APPROVED",
        "repository": {
          "id": "thisIsAFakeID="
        },
        "commits": {
          "nodes": [
            {
              "commit": {
                "oid": "123abc",
                "messageHeadline": "This is a cool commit",
                "messageBody": "Commit message\n\ncommit-id
:abc123",
                "statusCheckRollup": null
              }
            }
          ]
        }
      }
    }
  }
}
```

This prevented me from merging PRs in the stack as the status check would always fail. This fix makes null statusCheckRollups a pass instead.

I rebuilt this executable locally and was able to move my PRs along with no issue.