### PR TITLE
Disable git verbose commits and abbreviated rebase commands by default

### DIFF
--- a/git/realgit/realcmd.go
+++ b/git/realgit/realcmd.go
@@ -59,7 +59,11 @@ func (c *gitcmd) GitWithEditor(argStr string, output *string, editorCmd string) 
 	if c.config.User.LogGitCommands {
 		fmt.Printf("> git %s\n", argStr)
 	}
-	args := []string{"-c", fmt.Sprintf("core.editor=%s", editorCmd)}
+	args := []string{
+		"-c", fmt.Sprintf("core.editor=%s", editorCmd),
+		"-c", "commit.verbose=false",
+		"-c", "rebase.abbreviateCommands=false",
+	}
 	args = append(args, strings.Split(argStr, " ")...)
 	cmd := exec.Command("git", args...)
 	cmd.Dir = c.rootdir


### PR DESCRIPTION
This change disables (1) `commit.verbose` and (2) `rebase.abbreviateCommands` by default.

(1) Fixes https://github.com/ejoffe/spr/issues/316, but should be verified by @felixge

(2) Fixes https://github.com/ejoffe/spr/issues/409 for me.