### PR TITLE
Fix segfault when running update with --count=1 on a stack with more than one commit

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -484,7 +484,7 @@ func sortPullRequestsByLocalCommitOrder(pullRequests []*github.PullRequest, loca
 
 	var sortedPullRequests []*github.PullRequest
 	for _, commit := range localCommits {
-		if !commit.WIP {
+		if !commit.WIP && pullRequestMap[commit.CommitID] != nil {
 			sortedPullRequests = append(sortedPullRequests, pullRequestMap[commit.CommitID])
 		}
 	}


### PR DESCRIPTION
This fixes https://github.com/ejoffe/spr/issues/420 

`sortPullRequestsByLocalCommitOrder` assumes that all commits in the stack will have a corresponding PR, which is not true.

Now I just need to figure out how to add a test for this ;)