### PR TITLE
Refactor no-rebase logic to not use env var kludge

### DIFF
--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -150,10 +150,14 @@ VERSION: fork of {{.Version}}
 				Name:    "update",
 				Aliases: []string{"u", "up"},
 				Usage:   "Update and create pull requests for updated commits in the stack",
-				Action: func(c *cli.Context) error {
-					if c.Bool("no-rebase") {
-						os.Setenv("SPR_NOREBASE", "true")
+				Before: func(c *cli.Context) error {
+					// only override whatever was set in yaml if flag is explicitly present
+					if c.IsSet("no-rebase") {
+						cfg.User.NoRebase = c.Bool("no-rebase")
 					}
+					return nil
+				},
+				Action: func(c *cli.Context) error {
 					if c.IsSet("count") {
 						count := c.Uint("count")
 						stackedpr.UpdatePullRequests(ctx, c.StringSlice("reviewer"), &count)
@@ -178,6 +182,9 @@ VERSION: fork of {{.Version}}
 						Name:    "no-rebase",
 						Aliases: []string{"nr"},
 						Usage:   "Disable rebasing",
+						// this env var is needed as previous versions used the env var itself to pass intent to logic
+						// layer ops so it is likely relied on as a feature by users at this point
+						EnvVars: []string{"SPR_NOREBASE"},
 					},
 				},
 			},

--- a/git/realgit/realcmd.go
+++ b/git/realgit/realcmd.go
@@ -64,8 +64,7 @@ func (c *gitcmd) GitWithEditor(argStr string, output *string, editorCmd string) 
 	//  if output is not nil it will be set to the output of the command
 
 	// Rebase disabled
-	_, noRebaseFlag := os.LookupEnv("SPR_NOREBASE")
-	if (c.config.User.NoRebase || noRebaseFlag) && strings.HasPrefix(argStr, "rebase") {
+	if (c.config.User.NoRebase) && strings.HasPrefix(argStr, "rebase") {
 		return nil
 	}
 


### PR DESCRIPTION
This pull request cleans up the handling of the n-rebase flag/configuration behaviour.