### PR TITLE
Add defaultReviewers repo config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,9 @@ type RepoConfig struct {
 	GitHubRemote string `default:"origin" yaml:"githubRemote"`
 	GitHubBranch string `default:"main" yaml:"githubBranch"`
 
-	RequireChecks   bool `default:"true" yaml:"requireChecks"`
-	RequireApproval bool `default:"true" yaml:"requireApproval"`
+	RequireChecks    bool     `default:"true" yaml:"requireChecks"`
+	RequireApproval  bool     `default:"true" yaml:"requireApproval"`
+	DefaultReviewers []string `yaml:"defaultReviewers"`
 
 	MergeMethod string `default:"rebase" yaml:"mergeMethod"`
 	MergeQueue  bool   `default:"false" yaml:"mergeQueue"`

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ User specific configuration is saved to .spr.yml in the user home directory.
 | branchNameIncludeTarget | bool | false      | include target branch name in pull request branch name |
 | showPrTitlesInStack     | bool | false      | show PR titles in stack description within pull request body |
 | branchPushIndividually  | bool | false      | push branches individually instead of atomically (only enable to avoid timeouts) |
-
+| defaultReviewers        | list |            | default reviewers to add to each pull request |
 
 | User Config          | Type | Default | Description                                                     |
 | -------------------- | ---- | ------- | --------------------------------------------------------------- |

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -134,6 +134,7 @@ func alignLocalCommits(commits []git.Commit, prs []*github.PullRequest) []git.Co
 //	 will also be reordered to match the commit stack order.
 func (sd *stackediff) UpdatePullRequests(ctx context.Context, reviewers []string, count *uint) {
 	sd.profiletimer.Step("UpdatePullRequests::Start")
+	reviewers = append(sd.config.Repo.DefaultReviewers, reviewers...)
 	githubInfo := sd.fetchAndGetGitHubInfo(ctx)
 	if githubInfo == nil {
 		return


### PR DESCRIPTION
This pull request adds the capability to set default reviewers at the repo config level. Subsequent uses of the reviewer flag do not overwrite, but instead append to this list of reviewers.