### PR TITLE
Write SPR messages to a dedicated block inside commit messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 
 bin:
-	goreleaser --snapshot --skip-publish --clean
+	goreleaser --snapshot --skip=publish --clean
 

--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -825,3 +825,49 @@ func TestInsertBodyIntoPRTemplateErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestEmbedSprDescription(t *testing.T) {
+	existingBody := `# Some User Heading
+
+User paragraph that should remain untouched.
+
+<!-- SPR data start: please do NOT edit this section -->
+old spr content
+<!-- SPR data end -->
+
+Another user paragraph that should remain untouched as well.
+`
+
+	newSpr := `updated spr content with new data`
+
+	want := `# Some User Heading
+
+User paragraph that should remain untouched.
+
+<!-- SPR data start: please do NOT edit this section -->
+updated spr content with new data
+<!-- SPR data end -->
+
+Another user paragraph that should remain untouched as well.`
+	got := embedSprDescription(existingBody, newSpr)
+	if got != want {
+		t.Fatalf("Unexpected embedSprDescription result.\nGot:\n`%s`\n\nWant:\n`%s`\n", got, want)
+	}
+
+	// Test if markers are missing, we append them
+	existingBodyNoMarkers := `# Some User Heading
+
+No markers here.
+`
+	wantNoMarkers := `# Some User Heading
+
+No markers here.
+
+<!-- SPR data start: please do NOT edit this section -->
+updated spr content with new data
+<!-- SPR data end -->`
+	gotNoMarkers := embedSprDescription(existingBodyNoMarkers, newSpr)
+	if gotNoMarkers != wantNoMarkers {
+		t.Fatalf("Unexpected embedSprDescription result when markers are missing.\nGot:\n%s\n\nWant:\n%s\n", gotNoMarkers, wantNoMarkers)
+	}
+}


### PR DESCRIPTION
This fixes #435. 

### What/why
As noted in the issue, `git spr update` can overwrite changes made to the PR title/description. To fix this, we can have a dedicated block that looks like this, which the code can search for.
```
<!-- SPR data start: please do NOT edit this section -->
  
<!-- SPR data end -->
```

This way, any edits outside of this block are ignored. Since the block uses comments, it visually looks the same as before. And finally, if no block is present (e.g. on first commit or deleted by a user), it appends to the end.

### Test plan

I added new test cases. In addition, I ran a manual test which you can see in https://github.com/rohan-mehta/spr-test-repo. The process was:
1. Create 3 commits, `commit_1`, `commit_2`, `commit_3`, run `git spr update`, ensure that the spr stack description shows up.
2. Edit the PR for `commit_1` (add stuff above the block) and `commit_2` (add stuff above and below the block), then re-run `git spr update` and ensure that nothing is overwritten.
3. Amend `commit_2`, re-run `git spr update` and ensure that nothing is overwritten.
4. Create `commit_4` at the top of the stack, re-run `git spr update` and ensure that (a) a new PR is created (b) all previous PRs are updated to show the new commit (c) edits aren't overwritten
