### PR TITLE
Don't update stack for `merge` (ever)

### DIFF
--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -190,7 +190,6 @@ VERSION: fork of {{.Version}}
 						stackedpr.MergePullRequests(ctx, &count)
 					} else {
 						stackedpr.MergePullRequests(ctx, nil)
-						stackedpr.UpdatePullRequests(ctx, nil, nil)
 					}
 					return nil
 				},


### PR DESCRIPTION
  Do not run `UpdatePullRequests` when running the `merge` subcommand.

  Suppose we have local commits: `c1`.
  We do a git spr update and a PR is created for `c1`.
  We then create local commits `c2` & `c3`.

  If we run `git spr merge` then the following happens.

  1. `c1` got merged
  2. PRs are created for `c2` and `c3`

  The creation of PRs for `c2` and `c3` is both unexpected and undocumented.
  The use of `git spr merge` only claims to "merge all the pull requests that are
  mergeable in one shot".

  If you want to only merge some of the PRs then `git spr merge -c` is still available. If you want to create PRs for `c2` and `c3` then `git spr update` can still be used.

Note: This change was inspired by de380f0d2e505b43569fe2b3df0a05df4c3c0cf0.