### PR TITLE
Fix goreleaser: Upgrade to v2 format and command line flag migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: go test -race -coverprofile=./coverage.txt -covermode=atomic ./...
 
     - name: Check goreleaser file
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v6.2.1
       with:
         version: latest
         args: check --soft

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6.2.1
       with:
         version: latest
-        args: "check --soft"
+        args: check
 
     #- name: Upload coverage
     #  uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         version: latest
-        args: check
+        args: check --soft
 
     #- name: Upload coverage
     #  uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6.2.1
       with:
         version: latest
-        args: check --soft
+        args: "check --soft"
 
     #- name: Upload coverage
     #  uses: codecov/codecov-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 env:
   - GO111MODULE=on
 before:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,11 +36,11 @@ archives:
   - name_template: '{{ .ProjectName }}_{{- if eq .Os "Darwin" }}macos_{{- else }}{{- tolower .Os }}_{{end}}{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
     - goos: windows
-      format: zip
+      formats: ['zip']
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
@@ -87,3 +87,4 @@ publishers:
       - packages
     dir: "{{ dir .ArtifactPath }}"
     cmd: curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/{{ .Env.FURY_ORG }}/
+  

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 
 bin:
-	goreleaser --snapshot --skip-publish --clean
+	goreleaser --snapshot --skip=publish --clean
 


### PR DESCRIPTION
Fix #427

> --skip
>
>     since 2023-09-14 (v1.21), removed 2024-05-26 (v2.0)
>
> The following goreleaser release flags were deprecated:
>
>     --skip-announce
>     --skip-before
>     --skip-docker
>     --skip-ko
>     --skip-publish
>     --skip-sbom
>     --skip-sign
>     --skip-validate

See https://goreleaser.com/deprecations/#-skip

This also fixes a problem with the version of the `.goreleaser.yml`
which now has to be `version: 2`.

In order for the github workflow to not error with this message:

```console
$ goreleaser check
  • by using this software you agree with its EULA, available at https://goreleaser.com/eula
  • running goreleaser v2.7.0
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have https://black.readthedocs.io/en/stable/integrations/source_version_control.html
```

I had to update the `.gorelease.yml` according to the `DEPRECATED` links in the output above.