### PR TITLE
build: build only native executables by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 
 bin:
-	goreleaser --snapshot --skip=publish --clean
+	goreleaser build --snapshot --clean --single-target
 


### PR DESCRIPTION
`make bin` only builds native executables now.

I believe this is what the user would expect when they compile spr from source, and run `make bin` as instructed in readme.md.