### PR TITLE
Allow suppressing github starring option

### DIFF
--- a/github/githubclient/star.go
+++ b/github/githubclient/star.go
@@ -24,12 +24,17 @@ func (c *client) MaybeStar(ctx context.Context, cfg *config.Config) {
 	if !cfg.State.Stargazer && cfg.State.RunCount%promptCycle == 0 {
 		starred, err := c.isStar(ctx)
 		if err != nil {
-			fmt.Println("enjoying git spr? [Y/n]")
+			fmt.Println("enjoying git spr? [Y/n/d] (d = don't ask again)")
 			fmt.Print("  please add a star at https://github.com/ejoffe/spr")
 			reader := bufio.NewReader(os.Stdin)
 			line, _ := reader.ReadString('\n')
 			line = strings.TrimSpace(line)
-			if line != "n" {
+			if line == "d" {
+				cfg.State.Stargazer = true
+				rake.LoadSources(cfg.State,
+					rake.YamlFileWriter(config_parser.InternalConfigFilePath()))
+				fmt.Println("OK, won't ask again!")
+			} else if line != "n" {
 				cfg.State.Stargazer = true
 				rake.LoadSources(cfg.State,
 					rake.YamlFileWriter(config_parser.InternalConfigFilePath()))
@@ -44,11 +49,16 @@ func (c *client) MaybeStar(ctx context.Context, cfg *config.Config) {
 				rake.YamlFileWriter(config_parser.InternalConfigFilePath()))
 		} else {
 			log.Debug().Bool("stargazer", false).Msg("MaybeStar")
-			fmt.Print("enjoying git spr? add a GitHub star? [Y/n]:")
+			fmt.Print("enjoying git spr? add a GitHub star? [Y/n/d] (d = don't ask again): ")
 			reader := bufio.NewReader(os.Stdin)
 			line, _ := reader.ReadString('\n')
 			line = strings.TrimSpace(line)
-			if line != "n" {
+			if line == "d" {
+				cfg.State.Stargazer = true
+				rake.LoadSources(cfg.State,
+					rake.YamlFileWriter(config_parser.InternalConfigFilePath()))
+				fmt.Println("OK, won't ask again!")
+			} else if line != "n" {
 				log.Debug().Msg("MaybeStar : adding star")
 				c.addStar(ctx)
 				cfg.State.Stargazer = true


### PR DESCRIPTION
Thanks for the great library! I use it extensively at work.

Unfortunately due to strict Github Enterprise restrictions, starring repos outside of my org is prohibited by rules.

This means that once every 25 cycles, I get asked to star, but pressing `Y` errors out in a way that I get asked again.

I've set it manually in my `~/.spr/state` now to suppress the ask, but wondering if this would help others in my situation.

Given that this is an edge case, I won't blame you if you reject this PR.