### PR TITLE
fix: allow standard Git trailer format for commit-id

### DIFF
--- a/git/commit_test.go
+++ b/git/commit_test.go
@@ -93,6 +93,27 @@ Date:   Wed May 21 19:52:51 1980 -0700
 			expectedValid: true,
 		},
 		{
+			name: "SingleValidCommitWithSpaceAfterColon",
+			inputCommitLog: `
+commit d89e0e460ed817c81641f32b1a506b60164b4403 (HEAD -> master)
+Author: Han Solo
+Date:   Wed May 21 19:53:12 1980 -0700
+
+	Supergalactic speed
+
+	commit-id: 053f6d16
+`,
+			expectedCommits: []Commit{
+				{
+					CommitHash: "d89e0e460ed817c81641f32b1a506b60164b4403",
+					CommitID:   "053f6d16",
+					Subject:    "Supergalactic speed",
+					Body:       "",
+				},
+			},
+			expectedValid: true,
+		},
+		{
 			name: "SingleCommitMissingCommitID",
 			inputCommitLog: `
 commit d89e0e460ed817c81641f32b1a506b60164b4403 (HEAD -> master)

--- a/git/helpers.go
+++ b/git/helpers.go
@@ -81,7 +81,7 @@ func parseLocalCommitStack(commitLog string) ([]Commit, bool) {
 	var commits []Commit
 
 	commitHashRegex := regexp.MustCompile(`^commit ([a-f0-9]{40})`)
-	commitIDRegex := regexp.MustCompile(`commit-id\:([a-f0-9]{8})`)
+	commitIDRegex := regexp.MustCompile(`commit-id\:\s*([a-f0-9]{8})`)
 
 	// The list of commits from the command line actually starts at the
 	//  most recent commit. In order to reverse the list we use a


### PR DESCRIPTION
When using `git interpret-trailers` to add a commit-id trailer, Git
normalizes the output to include a space after the colon:

- #465


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*