### PR TITLE
Fix prTemplateInsertEnd error output

### DIFF
--- a/github/template/template_custom/template.go
+++ b/github/template/template_custom/template.go
@@ -100,7 +100,7 @@ func (t *CustomTemplatizer) insertBodyIntoPRTemplate(body, prTemplate string, pr
 
 	endPRTemplateSection, err := getSectionOfPRTemplate(templateOrExistingPRBody, t.repoConfig.PRTemplateInsertEnd, AfterMatch)
 	if err != nil {
-		return "", fmt.Errorf("%w: PR template insert end = '%v'", err, t.repoConfig.PRTemplateInsertStart)
+		return "", fmt.Errorf("%w: PR template insert end = '%v'", err, t.repoConfig.PRTemplateInsertEnd)
 	}
 
 	return fmt.Sprintf("%v%v\n%v\n\n%v%v", startPRTemplateSection, t.repoConfig.PRTemplateInsertStart, body,


### PR DESCRIPTION
Previously when an error is returned for the PR template end string, the start string is displayed instead. This fixes the reference.

- #466
- #465


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*