### PR TITLE
Add PR templates

### DIFF
--- a/github/template/template_custom/template.go
+++ b/github/template/template_custom/template.go
@@ -43,7 +43,7 @@ func (t *CustomTemplatizer) Body(info *github.GitHubInfo, commit git.Commit) str
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to insert body into PR template")
 	}
-	return commit.Body
+	return body
 }
 
 func (t *CustomTemplatizer) formatBody(commit git.Commit, stack []*github.PullRequest) string {


### PR DESCRIPTION
Current template options include:
- basic : just use the commit title and body
- stack : like basic but also show stack of prs
- custom : use custom pr template
- why_what : first section of body explains why, second section is what

- #470
- #469
- #468
- #467
- #466
- #465


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*