### PR TITLE
feat: when using custom PR templates - prompt user to fill it in

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -385,7 +385,7 @@ func (c *client) CreatePullRequest(ctx context.Context, gitcmd git.GitInterface,
 
 	templatizer := config_fetcher.PRTemplatizer(c.config, gitcmd)
 
-	body := templatizer.Body(info, commit)
+	body := templatizer.Body(info, commit, nil)
 	resp, err := c.api.CreatePullRequest(ctx, genclient.CreatePullRequestInput{
 		RepositoryId: info.RepositoryID,
 		BaseRefName:  baseRefName,
@@ -403,6 +403,7 @@ func (c *client) CreatePullRequest(ctx context.Context, gitcmd git.GitInterface,
 		ToBranch:   baseRefName,
 		Commit:     commit,
 		Title:      commit.Subject,
+		Body:       resp.CreatePullRequest.PullRequest.Body,
 		MergeStatus: github.PullRequestMergeStatus{
 			ChecksPass:     github.CheckStatusUnknown,
 			ReviewApproved: false,
@@ -437,7 +438,7 @@ func (c *client) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface,
 
 	templatizer := config_fetcher.PRTemplatizer(c.config, gitcmd)
 	title := templatizer.Title(info, commit)
-	body := templatizer.Body(info, commit)
+	body := templatizer.Body(info, commit, pr)
 	input := genclient.UpdatePullRequestInput{
 		PullRequestId: pr.ID,
 		Title:         &title,

--- a/github/githubclient/gen/genclient/client.go
+++ b/github/githubclient/gen/genclient/client.go
@@ -34,48 +34,48 @@ type Client interface {
 		input CreatePullRequestInput,
 	) (*CreatePullRequestResponse, error)
 
-	// UpdatePullRequest from github/githubclient/queries.graphql:115
+	// UpdatePullRequest from github/githubclient/queries.graphql:116
 	UpdatePullRequest(ctx context.Context,
 		input UpdatePullRequestInput,
 	) (*UpdatePullRequestResponse, error)
 
-	// AddReviewers from github/githubclient/queries.graphql:127
+	// AddReviewers from github/githubclient/queries.graphql:128
 	AddReviewers(ctx context.Context,
 		input RequestReviewsInput,
 	) (*AddReviewersResponse, error)
 
-	// CommentPullRequest from github/githubclient/queries.graphql:139
+	// CommentPullRequest from github/githubclient/queries.graphql:140
 	CommentPullRequest(ctx context.Context,
 		input AddCommentInput,
 	) (*CommentPullRequestResponse, error)
 
-	// MergePullRequest from github/githubclient/queries.graphql:149
+	// MergePullRequest from github/githubclient/queries.graphql:150
 	MergePullRequest(ctx context.Context,
 		input MergePullRequestInput,
 	) (*MergePullRequestResponse, error)
 
-	// AutoMergePullRequest from github/githubclient/queries.graphql:161
+	// AutoMergePullRequest from github/githubclient/queries.graphql:162
 	AutoMergePullRequest(ctx context.Context,
 		input EnablePullRequestAutoMergeInput,
 	) (*AutoMergePullRequestResponse, error)
 
-	// ClosePullRequest from github/githubclient/queries.graphql:173
+	// ClosePullRequest from github/githubclient/queries.graphql:174
 	ClosePullRequest(ctx context.Context,
 		input ClosePullRequestInput,
 	) (*ClosePullRequestResponse, error)
 
-	// StarCheck from github/githubclient/queries.graphql:185
+	// StarCheck from github/githubclient/queries.graphql:186
 	StarCheck(ctx context.Context,
 		after *string,
 	) (*StarCheckResponse, error)
 
-	// StarGetRepo from github/githubclient/queries.graphql:201
+	// StarGetRepo from github/githubclient/queries.graphql:202
 	StarGetRepo(ctx context.Context,
 		owner string,
 		name string,
 	) (*StarGetRepoResponse, error)
 
-	// StarAdd from github/githubclient/queries.graphql:210
+	// StarAdd from github/githubclient/queries.graphql:211
 	StarAdd(ctx context.Context,
 		input AddStarInput,
 	) (*StarAddResponse, error)

--- a/github/githubclient/gen/genclient/operations.go
+++ b/github/githubclient/gen/genclient/operations.go
@@ -278,6 +278,7 @@ type CreatePullRequestCreatePullRequest struct {
 type CreatePullRequestCreatePullRequestPullRequest struct {
 	Id     string
 	Number int
+	Body   string
 }
 
 // CreatePullRequestResponse response type for CreatePullRequest
@@ -296,6 +297,7 @@ func (c *gqlclient) CreatePullRequest(ctx context.Context,
 		pullRequest {
 			id
 			number
+			body
 		}
 	}
 }
@@ -343,7 +345,7 @@ type UpdatePullRequestResponse struct {
 	UpdatePullRequest *UpdatePullRequestUpdatePullRequest
 }
 
-// UpdatePullRequest from github/githubclient/queries.graphql:115
+// UpdatePullRequest from github/githubclient/queries.graphql:116
 func (c *gqlclient) UpdatePullRequest(ctx context.Context,
 	input UpdatePullRequestInput,
 ) (*UpdatePullRequestResponse, error) {
@@ -400,7 +402,7 @@ type AddReviewersResponse struct {
 	RequestReviews *AddReviewersRequestReviews
 }
 
-// AddReviewers from github/githubclient/queries.graphql:127
+// AddReviewers from github/githubclient/queries.graphql:128
 func (c *gqlclient) AddReviewers(ctx context.Context,
 	input RequestReviewsInput,
 ) (*AddReviewersResponse, error) {
@@ -453,7 +455,7 @@ type CommentPullRequestResponse struct {
 	AddComment *CommentPullRequestAddComment
 }
 
-// CommentPullRequest from github/githubclient/queries.graphql:139
+// CommentPullRequest from github/githubclient/queries.graphql:140
 func (c *gqlclient) CommentPullRequest(ctx context.Context,
 	input AddCommentInput,
 ) (*CommentPullRequestResponse, error) {
@@ -508,7 +510,7 @@ type MergePullRequestResponse struct {
 	MergePullRequest *MergePullRequestMergePullRequest
 }
 
-// MergePullRequest from github/githubclient/queries.graphql:149
+// MergePullRequest from github/githubclient/queries.graphql:150
 func (c *gqlclient) MergePullRequest(ctx context.Context,
 	input MergePullRequestInput,
 ) (*MergePullRequestResponse, error) {
@@ -565,7 +567,7 @@ type AutoMergePullRequestResponse struct {
 	EnablePullRequestAutoMerge *AutoMergePullRequestEnablePullRequestAutoMerge
 }
 
-// AutoMergePullRequest from github/githubclient/queries.graphql:161
+// AutoMergePullRequest from github/githubclient/queries.graphql:162
 func (c *gqlclient) AutoMergePullRequest(ctx context.Context,
 	input EnablePullRequestAutoMergeInput,
 ) (*AutoMergePullRequestResponse, error) {
@@ -622,7 +624,7 @@ type ClosePullRequestResponse struct {
 	ClosePullRequest *ClosePullRequestClosePullRequest
 }
 
-// ClosePullRequest from github/githubclient/queries.graphql:173
+// ClosePullRequest from github/githubclient/queries.graphql:174
 func (c *gqlclient) ClosePullRequest(ctx context.Context,
 	input ClosePullRequestInput,
 ) (*ClosePullRequestResponse, error) {
@@ -689,7 +691,7 @@ type StarCheckResponse struct {
 	Viewer StarCheckViewer
 }
 
-// StarCheck from github/githubclient/queries.graphql:185
+// StarCheck from github/githubclient/queries.graphql:186
 func (c *gqlclient) StarCheck(ctx context.Context,
 	after *string,
 ) (*StarCheckResponse, error) {
@@ -748,7 +750,7 @@ type StarGetRepoResponse struct {
 	Repository *StarGetRepoRepository
 }
 
-// StarGetRepo from github/githubclient/queries.graphql:201
+// StarGetRepo from github/githubclient/queries.graphql:202
 func (c *gqlclient) StarGetRepo(ctx context.Context,
 	owner string,
 	name string,
@@ -801,7 +803,7 @@ type StarAddResponse struct {
 	AddStar *StarAddAddStar
 }
 
-// StarAdd from github/githubclient/queries.graphql:210
+// StarAdd from github/githubclient/queries.graphql:211
 func (c *gqlclient) StarAdd(ctx context.Context,
 	input AddStarInput,
 ) (*StarAddResponse, error) {

--- a/github/githubclient/queries.graphql
+++ b/github/githubclient/queries.graphql
@@ -108,6 +108,7 @@ mutation CreatePullRequest(
 		pullRequest {
 			id
 			number
+			body
 		}
 	}
 }

--- a/github/template/interface.go
+++ b/github/template/interface.go
@@ -7,5 +7,5 @@ import (
 
 type PRTemplatizer interface {
 	Title(info *github.GitHubInfo, commit git.Commit) string
-	Body(info *github.GitHubInfo, commit git.Commit) string
+	Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string
 }

--- a/github/template/template_basic/template.go
+++ b/github/template/template_basic/template.go
@@ -16,7 +16,7 @@ func (t *BasicTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) str
 	return commit.Subject
 }
 
-func (t *BasicTemplatizer) Body(info *github.GitHubInfo, commit git.Commit) string {
+func (t *BasicTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
 	body := commit.Body
 	body += "\n\n"
 	body += template.ManualMergeNotice()

--- a/github/template/template_basic/template_test.go
+++ b/github/template/template_basic/template_test.go
@@ -194,7 +194,7 @@ func TestBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := templatizer.Body(info, tt.commit)
+			got := templatizer.Body(info, tt.commit, nil)
 
 			// Verify all expected strings are present
 			for _, wantStr := range tt.wantContains {
@@ -229,7 +229,7 @@ func TestBodyManualMergeNoticeFormat(t *testing.T) {
 		Body:    "Test body",
 	}
 
-	result := templatizer.Body(info, commit)
+	result := templatizer.Body(info, commit, nil)
 
 	// Verify the exact format of the manual merge notice
 	expectedNotice := "⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*"
@@ -280,7 +280,7 @@ func TestBodyPreservesOriginalContent(t *testing.T) {
 				Body:    tc.body,
 			}
 
-			result := templatizer.Body(info, commit)
+			result := templatizer.Body(info, commit, nil)
 
 			// The result should contain the original body (if not empty)
 			if tc.body != "" {
@@ -349,7 +349,7 @@ Performance improvements:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := templatizer.Body(info, tt.commit)
+			result := templatizer.Body(info, tt.commit, nil)
 
 			// Should contain the original body content
 			assert.Contains(t, result, tt.commit.Body)

--- a/github/template/template_stack/template.go
+++ b/github/template/template_stack/template.go
@@ -18,7 +18,7 @@ func (t *StackTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) str
 	return commit.Subject
 }
 
-func (t *StackTemplatizer) Body(info *github.GitHubInfo, commit git.Commit) string {
+func (t *StackTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
 	body := commit.Body
 
 	// Always show stack section and notice

--- a/github/template/template_stack/template_test.go
+++ b/github/template/template_stack/template_test.go
@@ -79,7 +79,7 @@ func TestBody_EmptyStack(t *testing.T) {
 		Body:    "Commit body text",
 	}
 
-	result := templatizer.Body(info, commit)
+	result := templatizer.Body(info, commit, nil)
 
 	// Should contain the commit body
 	assert.Contains(t, result, "Commit body text")
@@ -133,7 +133,7 @@ func TestBody_WithStack_NoTitles(t *testing.T) {
 	}
 
 	// Test with commit2 (middle of stack)
-	result := templatizer.Body(info, commit2)
+	result := templatizer.Body(info, commit2, nil)
 
 	// Should contain the commit body
 	assert.Contains(t, result, "Second body")
@@ -210,7 +210,7 @@ func TestBody_WithStack_WithTitles(t *testing.T) {
 	}
 
 	// Test with commit2 (middle of stack)
-	result := templatizer.Body(info, commit2)
+	result := templatizer.Body(info, commit2, nil)
 
 	// Should contain the commit body
 	assert.Contains(t, result, "Second body")
@@ -254,7 +254,7 @@ func TestBody_StackOrder(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit2)
+	result := templatizer.Body(info, commit2, nil)
 
 	// Stack should be in reverse order (3, 2, 1)
 	// Find the stack section
@@ -305,7 +305,7 @@ func TestBody_CurrentCommitAtStart(t *testing.T) {
 	}
 
 	// Test with commit3 (last in stack, first in reverse order)
-	result := templatizer.Body(info, commit3)
+	result := templatizer.Body(info, commit3, nil)
 
 	// Should have arrow on #3
 	assert.Contains(t, result, "#3 ⬅")
@@ -343,7 +343,7 @@ func TestBody_CurrentCommitAtEnd(t *testing.T) {
 	}
 
 	// Test with commit1 (first in stack, last in reverse order)
-	result := templatizer.Body(info, commit1)
+	result := templatizer.Body(info, commit1, nil)
 
 	// Should have arrow on #1
 	assert.Contains(t, result, "#1 ⬅")
@@ -368,7 +368,7 @@ func TestBody_EmptyBody(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit)
+	result := templatizer.Body(info, commit, nil)
 
 	// Should still contain stack and notice
 	assert.Contains(t, result, "#1")
@@ -391,7 +391,7 @@ func TestBody_SinglePRInStack(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit)
+	result := templatizer.Body(info, commit, nil)
 
 	// Should contain the body
 	assert.Contains(t, result, "Single body")
@@ -427,7 +427,7 @@ func TestBody_WithTitlesVsWithoutTitles(t *testing.T) {
 
 	// Test without titles
 	templatizerNoTitles := NewStackTemplatizer(false)
-	resultNoTitles := templatizerNoTitles.Body(info, commit2)
+	resultNoTitles := templatizerNoTitles.Body(info, commit2, nil)
 
 	// Should NOT contain PR titles
 	assert.NotContains(t, resultNoTitles, "First PR")
@@ -438,7 +438,7 @@ func TestBody_WithTitlesVsWithoutTitles(t *testing.T) {
 
 	// Test with titles
 	templatizerWithTitles := NewStackTemplatizer(true)
-	resultWithTitles := templatizerWithTitles.Body(info, commit2)
+	resultWithTitles := templatizerWithTitles.Body(info, commit2, nil)
 
 	// Should contain PR titles
 	assert.Contains(t, resultWithTitles, "First PR #1")
@@ -460,7 +460,7 @@ func TestBody_Structure(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit)
+	result := templatizer.Body(info, commit, nil)
 
 	// Verify structure: body + \n\n + stack + \n\n + notice
 	// The body should come first
@@ -513,7 +513,7 @@ func TestBody_RealWorldExample(t *testing.T) {
 	}
 
 	// Test with middle commit
-	result := templatizer.Body(info, commit2)
+	result := templatizer.Body(info, commit2, nil)
 
 	// Should contain commit body
 	assert.Contains(t, result, "Created POST /login endpoint")
@@ -608,7 +608,7 @@ It even includes some **markdown** formatting.
 	templatizer := NewStackTemplatizer(false)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			body := templatizer.Body(tc.info, tc.commit)
+			body := templatizer.Body(tc.info, tc.commit, nil)
 			if body != tc.expected {
 				t.Fatalf("expected: '%v', actual: '%v'", tc.expected, body)
 			}

--- a/github/template/template_why_what/template.go
+++ b/github/template/template_why_what/template.go
@@ -20,7 +20,7 @@ func (t *WhyWhatTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) s
 	return commit.Subject
 }
 
-func (t *WhyWhatTemplatizer) Body(info *github.GitHubInfo, commit git.Commit) string {
+func (t *WhyWhatTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
 	// Split commit body by empty lines and filter out empty sections
 	sections := splitByEmptyLines(commit.Body)
 

--- a/github/template/template_why_what/template_test.go
+++ b/github/template/template_why_what/template_test.go
@@ -212,7 +212,7 @@ func TestBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := templatizer.Body(info, tt.commit)
+			got := templatizer.Body(info, tt.commit, nil)
 
 			// Check that all required strings are present
 			for _, wantStr := range tt.contains {
@@ -320,7 +320,7 @@ func TestBodyTemplateStructure(t *testing.T) {
 		Body:    "Why section\n\nWhat changed section\n\nTest plan section",
 	}
 
-	result := templatizer.Body(info, commit)
+	result := templatizer.Body(info, commit, nil)
 
 	// Verify sections appear in correct order
 	whyIndex := strings.Index(result, "Why\n===")
@@ -381,7 +381,7 @@ Manual review of the docs.`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := templatizer.Body(info, tt.commit)
+			result := templatizer.Body(info, tt.commit, nil)
 
 			// Should always contain the required sections
 			assert.Contains(t, result, "Why\n===")


### PR DESCRIPTION
Feature specifically for custom PR templates.

Workflow changes:

1. git commit
2. git spr u
3. You are prompted:
```

New PR for:
  be5e446: upd

Edit PR content? [Y/n]: Y

```
(If SPR creates multiple PRs, you will have an opportunity to fill in each one.)

This prompt appears only during PR creation. There is no prompt when updating an existing PR - for example, when a new PR is added to the stack and SPR updates the description of each parent PR, or when one of the PRs in the stack is amended.