### PR TITLE
feat: make branch prefix configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,12 +50,13 @@ type UserConfig struct {
 	StatusBitsHeader bool `default:"true" yaml:"statusBitsHeader"`
 	StatusBitsEmojis bool `default:"true" yaml:"statusBitsEmojis"`
 
-	CreateDraftPRs       bool `default:"false" yaml:"createDraftPRs"`
-	PreserveTitleAndBody bool `default:"false" yaml:"preserveTitleAndBody"`
-	NoRebase             bool `default:"false" yaml:"noRebase"`
+	CreateDraftPRs       bool   `default:"false" yaml:"createDraftPRs"`
+	PreserveTitleAndBody bool   `default:"false" yaml:"preserveTitleAndBody"`
+	NoRebase             bool   `default:"false" yaml:"noRebase"`
 	DeleteMergedBranches bool `default:"false" yaml:"deleteMergedBranches"`
 	ShortPRLink          bool `default:"false" yaml:"shortPRLink"`
 	ShowCommitID         bool `default:"false" yaml:"showCommitID"`
+	BranchPrefix         string `default:"spr" yaml:"branchPrefix"`
 }
 
 type InternalState struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,7 @@ func TestDefaultConfig(t *testing.T) {
 			LogGitHubCalls:   false,
 			StatusBitsHeader: true,
 			StatusBitsEmojis: true,
+			BranchPrefix:     "spr",
 		},
 		State: &InternalState{
 			MergeCheckCommit: map[string]string{},

--- a/git/helpers.go
+++ b/git/helpers.go
@@ -26,10 +26,13 @@ func GetLocalBranchName(gitcmd GitInterface) string {
 
 func BranchNameFromCommit(cfg *config.Config, commit Commit) string {
 	remoteBranchName := cfg.Repo.GitHubBranch
-	return "spr/" + remoteBranchName + "/" + commit.CommitID
+	branchPrefix := cfg.User.BranchPrefix
+	return branchPrefix + "/" + remoteBranchName + "/" + commit.CommitID
 }
 
-var BranchNameRegex = regexp.MustCompile(`spr/([a-zA-Z0-9_\-/\.]+)/([a-f0-9]{8})$`)
+func BranchNameRegex(branchPrefix string) *regexp.Regexp {
+	return regexp.MustCompile(regexp.QuoteMeta(branchPrefix) + `/([a-zA-Z0-9_\-/\.]+)/([a-f0-9]{8})$`)
+}
 
 // GetLocalTopCommit returns the top unmerged commit in the stack
 //

--- a/git/helpers_test.go
+++ b/git/helpers_test.go
@@ -1,23 +1,85 @@
 package git
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ejoffe/spr/config"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestBranchNameRegex(t *testing.T) {
 	tests := []struct {
+		prefix string
 		input  string
 		branch string
 		commit string
 	}{
-		{input: "spr/b1/deadbeef", branch: "b1", commit: "deadbeef"},
+		{prefix: "spr", input: "spr/b1/deadbeef", branch: "b1", commit: "deadbeef"},
+		{prefix: "spr", input: "spr/main/abcd1234", branch: "main", commit: "abcd1234"},
+		{prefix: "custom", input: "custom/main/deadbeef", branch: "main", commit: "deadbeef"},
+		{prefix: "my-team", input: "my-team/develop/abcd1234", branch: "develop", commit: "abcd1234"},
 	}
 
 	for _, tc := range tests {
-		matches := BranchNameRegex.FindStringSubmatch(tc.input)
-		if tc.branch != matches[1] {
-			t.Fatalf("expected: '%v', actual: '%v'", tc.branch, matches[1])
-		}
-		if tc.commit != matches[2] {
-			t.Fatalf("expected: '%v', actual: '%v'", tc.commit, matches[2])
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			matches := BranchNameRegex(tc.prefix).FindStringSubmatch(tc.input)
+			assert.NotNil(t, matches)
+			assert.Equal(t, tc.branch, matches[1])
+			assert.Equal(t, tc.commit, matches[2])
+		})
+	}
+}
+
+func TestBranchNameRegexNoMatch(t *testing.T) {
+	tests := []struct {
+		prefix string
+		input  string
+	}{
+		{prefix: "spr", input: "other/main/deadbeef"},
+		{prefix: "custom", input: "spr/main/deadbeef"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			matches := BranchNameRegex(tc.prefix).FindStringSubmatch(tc.input)
+			assert.Nil(t, matches)
+		})
+	}
+}
+
+func TestBranchNameFromCommit(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		branch   string
+		commitID string
+		expected string
+	}{
+		{
+			name:     "default prefix",
+			prefix:   "spr",
+			branch:   "main",
+			commitID: "deadbeef",
+			expected: "spr/main/deadbeef",
+		},
+		{
+			name:     "custom prefix",
+			prefix:   "my-team",
+			branch:   "develop",
+			commitID: "abcd1234",
+			expected: "my-team/develop/abcd1234",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.EmptyConfig()
+			cfg.User.BranchPrefix = tc.prefix
+			cfg.Repo.GitHubBranch = tc.branch
+
+			commit := Commit{CommitID: tc.commitID}
+			result := BranchNameFromCommit(cfg, commit)
+			assert.Equal(t, tc.expected, result)
+		})
 	}
 }

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -202,7 +202,7 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 	targetBranch := c.config.Repo.GitHubBranch
 	localCommitStack := git.GetLocalCommitStack(c.config, gitcmd)
 
-	pullRequests := matchPullRequestStack(c.config.Repo, targetBranch, localCommitStack, pullRequestConnection)
+	pullRequests := matchPullRequestStack(c.config.Repo, c.config.User.BranchPrefix, targetBranch, localCommitStack, pullRequestConnection)
 	for _, pr := range pullRequests {
 		if pr.Ready(c.config) {
 			pr.MergeStatus.Stacked = true
@@ -224,6 +224,7 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 
 func matchPullRequestStack(
 	repoConfig *config.RepoConfig,
+	branchPrefix string,
 	targetBranch string,
 	localCommitStack []git.Commit,
 	allPullRequests fezzik_types.PullRequestConnection) []*github.PullRequest {
@@ -260,7 +261,7 @@ func matchPullRequestStack(
 			InQueue:    node.MergeQueueEntry != nil,
 		}
 
-		matches := git.BranchNameRegex.FindStringSubmatch(node.HeadRefName)
+		matches := git.BranchNameRegex(branchPrefix).FindStringSubmatch(node.HeadRefName)
 		if matches != nil {
 			commit := (*node.Commits.Nodes)[len(*node.Commits.Nodes)-1].Commit
 			pullRequest.Commit = git.Commit{
@@ -329,7 +330,7 @@ func matchPullRequestStack(
 			break
 		}
 
-		matches := git.BranchNameRegex.FindStringSubmatch(currpr.ToBranch)
+		matches := git.BranchNameRegex(branchPrefix).FindStringSubmatch(currpr.ToBranch)
 		if matches == nil {
 			panic(fmt.Errorf("invalid base branch for pull request:%s", currpr.ToBranch))
 		}

--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -523,7 +523,7 @@ func TestMatchPullRequestStack(t *testing.T) {
 	for _, tc := range tests {
 		repoConfig := &config.RepoConfig{}
 		t.Run(tc.name, func(t *testing.T) {
-			actual := matchPullRequestStack(repoConfig, "master", tc.commits, tc.prs)
+			actual := matchPullRequestStack(repoConfig, "spr", "master", tc.commits, tc.prs)
 			require.Equal(t, tc.expect, actual)
 		})
 	}

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -635,7 +635,7 @@ func (sd *stackediff) fetchAndGetGitHubInfo(ctx context.Context) *github.GitHubI
 		return nil
 	}
 	info := sd.github.GetInfo(ctx, sd.gitcmd)
-	if git.BranchNameRegex.FindString(info.LocalBranch) != "" {
+	if git.BranchNameRegex(sd.config.User.BranchPrefix).FindString(info.LocalBranch) != "" {
 		fmt.Printf("error: don't run spr in a remote pr branch\n")
 		fmt.Printf(" this could lead to weird duplicate pull requests getting created\n")
 		fmt.Printf(" in general there is no need to checkout remote branches used for prs\n")

--- a/spr/spr_test.go
+++ b/spr/spr_test.go
@@ -25,6 +25,7 @@ func makeTestObjects(t *testing.T, synchronized bool) (
 	cfg.Repo.GitHubRemote = "origin"
 	cfg.Repo.GitHubBranch = "master"
 	cfg.Repo.MergeMethod = "rebase"
+	cfg.User.BranchPrefix = "spr"
 	gitmock = mockgit.NewMockGit(t)
 	githubmock = mockclient.NewMockClient(t)
 	githubmock.Info = &github.GitHubInfo{


### PR DESCRIPTION
Currently the branch prefix used for stacked PRs is hardcoded to `spr/`. This makes it impossible to customize the prefix for workflows where a different naming convention is needed (e.g. team-specific prefixes, or avoiding conflicts with other tools).

## Changes

- Add a `branchPrefix` field to both `UserConfig` (default: `spr`) and `RepoConfig`, with repo-level config taking precedence over user-level
- Add a `BranchPrefix()` method on `Config` that resolves the effective prefix (repo > user > default `spr`)
- Trailing slashes in the prefix are automatically stripped to avoid double slashes in branch names
- Convert `BranchNameRegex` from a hardcoded global variable to a function that builds the regex dynamically based on the configured prefix
- Use the configured prefix in `BranchNameFromCommit` instead of the hardcoded `spr/` string
- Update all call sites in `client.go` and `spr.go`

## Configuration

At user level (`~/.spr.yml`), applies to all repos:

```yaml
branchPrefix: "my-prefix"
```

At repo level (`.spr.yml` in the repo root), overrides user-level:

```yaml
branchPrefix: "team-x"
```

Slashes are supported in the prefix (e.g. `johndoe/spr`).

This is a non-breaking change — existing users will see no difference since the default remains `spr`.

## Test plan

- Added tests for `Config.BranchPrefix()`: default, user override, repo override, trailing slash stripping
- Added tests for `BranchNameFromCommit` with default and custom prefixes, including repo override
- Added tests for `BranchNameRegex` with custom prefixes
- Added negative tests ensuring wrong prefix does not match
- All existing tests pass