### PR TITLE
feat: add Jujutsu (jj) support via VCSOperations abstraction

### DIFF
--- a/cmd/amend/main.go
+++ b/cmd/amend/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ejoffe/spr/git/realgit"
 	"github.com/ejoffe/spr/github/githubclient"
 	"github.com/ejoffe/spr/spr"
+	"github.com/ejoffe/spr/vcs"
 	"github.com/jessevdk/go-flags"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -62,7 +63,8 @@ func main() {
 	client := githubclient.NewGitHubClient(ctx, cfg)
 	gitcmd = realgit.NewGitCmd(cfg)
 
-	sd := spr.NewStackedPR(cfg, client, gitcmd)
+	vcsOps := vcs.NewVCSOperations(cfg, gitcmd)
+	sd := spr.NewStackedPR(cfg, client, gitcmd, vcsOps)
 	sd.AmendCommit(ctx)
 
 	if opts.Update {

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/ejoffe/rake"
@@ -326,6 +327,25 @@ VERSION: fork of {{.Version}}
 				return nil
 			},
 		},
+			{
+				Name:  "jj-setup",
+				Usage: "Register 'jj spr' alias for use in Jujutsu repos",
+				Action: func(c *cli.Context) error {
+					cmd := exec.Command("jj", "config", "set", "--user",
+						"aliases.spr", `["util", "exec", "--", "git-spr"]`)
+					cmd.Stdout = os.Stdout
+					cmd.Stderr = os.Stderr
+					err := cmd.Run()
+					if err != nil {
+						return cli.Exit(fmt.Sprintf("Failed to set jj alias: %s", err), 1)
+					}
+					fmt.Println("jj alias registered. You can now use:")
+					fmt.Println("  jj spr update")
+					fmt.Println("  jj spr status")
+					fmt.Println("  jj spr merge")
+					return nil
+				},
+			},
 			{
 				Name:  "version",
 				Usage: "Show version info",

--- a/cmd/spr/main.go
+++ b/cmd/spr/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ejoffe/spr/git/realgit"
 	"github.com/ejoffe/spr/github/githubclient"
 	"github.com/ejoffe/spr/spr"
+	"github.com/ejoffe/spr/vcs"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -88,9 +89,21 @@ func main() {
 	}
 	gitcmd = realgit.NewGitCmd(cfg)
 
+	// Check for --no-jj flag or SPR_NOJJ env var before creating VCS operations.
+	// This must happen before app.Run() since vcsOps is created here.
+	for _, arg := range os.Args[1:] {
+		if arg == "--no-jj" {
+			cfg.User.NoJJ = true
+		}
+	}
+	if os.Getenv("SPR_NOJJ") == "true" {
+		cfg.User.NoJJ = true
+	}
+
 	ctx := context.Background()
 	client := githubclient.NewGitHubClient(ctx, cfg)
-	stackedpr := spr.NewStackedPR(cfg, client, gitcmd)
+	vcsOps := vcs.NewVCSOperations(cfg, gitcmd)
+	stackedpr := spr.NewStackedPR(cfg, client, gitcmd, vcsOps)
 
 	detailFlag := &cli.BoolFlag{
 		Name:  "detail",
@@ -145,6 +158,12 @@ VERSION: fork of {{.Version}}
 				Name:  "debug",
 				Value: false,
 				Usage: "Show runtime debug info",
+			},
+			&cli.BoolFlag{
+				Name:    "no-jj",
+				Value:   false,
+				Usage:   "Disable jj (Jujutsu) mode even in jj-colocated repos",
+				EnvVars: []string{"SPR_NOJJ"},
 			},
 		},
 		Before: func(c *cli.Context) error {

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type UserConfig struct {
 	CreateDraftPRs       bool `default:"false" yaml:"createDraftPRs"`
 	PreserveTitleAndBody bool `default:"false" yaml:"preserveTitleAndBody"`
 	NoRebase             bool `default:"false" yaml:"noRebase"`
+	NoJJ                 bool `default:"false" yaml:"noJJ"`
 	DeleteMergedBranches bool `default:"false" yaml:"deleteMergedBranches"`
 	ShortPRLink          bool `default:"false" yaml:"shortPRLink"`
 	ShowCommitID         bool `default:"false" yaml:"showCommitID"`

--- a/git/commit.go
+++ b/git/commit.go
@@ -20,6 +20,10 @@ type Commit struct {
 	// CommitHash is the git commit hash, this gets updated everytime the commit is amended.
 	CommitHash string
 
+	// ChangeID is the jj (Jujutsu) change ID. Only populated in jj-colocated repos.
+	// Unlike CommitHash, the ChangeID is stable across rewrites done via jj commands.
+	ChangeID string
+
 	// Subject is the subject of the commit message.
 	Subject string
 

--- a/git/mockgit/mockgit.go
+++ b/git/mockgit/mockgit.go
@@ -79,6 +79,11 @@ func (m *Mock) ExpectFetch() {
 	m.expect("git rebase origin/master --autostash")
 }
 
+func (m *Mock) ExpectFetchTags() {
+	m.expect("git fetch --tags --force")
+	m.expect("git rebase origin/master --autostash")
+}
+
 func (m *Mock) ExpectDeleteBranch(branchName string) {
 	m.expect(fmt.Sprintf("git DeleteRemoteBranch(%s)", branchName))
 }

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Commands
 | `git spr check`   |           | Run pre-merge checks (configured by `mergeCheck`) |
 | `git spr version` |           | Show version info |
 
-**Global flags:** `--detail` (show status bit headers), `--verbose` (log git commands and GitHub API calls), `--debug`, `--profile`
+**Global flags:** `--detail` (show status bit headers), `--verbose` (log git commands and GitHub API calls), `--no-jj` (disable jj mode), `--debug`, `--profile`
 
 Installation 
 ------------
@@ -230,9 +230,43 @@ User specific configuration is saved to .spr.yml in the user home directory.
 | createDraftPRs       | bool | false   | new pull requests are created as draft |
 | preserveTitleAndBody | bool | false   | updating pull requests will not overwrite the pr title and body |
 | noRebase             | bool | false   | when true spr update will not rebase on top of origin |
+| noJJ                 | bool | false   | disable jj (Jujutsu) mode even in jj-colocated repos (also `--no-jj` flag or `SPR_NOJJ` env var) |
 | deleteMergedBranches | bool | false   | delete branches after prs are merged |
 | shortPRLink          | bool | false   | show pull request links as clickable PR-<number> instead of full URL |
 | showCommitID         | bool | false   | show first 8 characters of commit hash for each pull request |
+
+Jujutsu (jj) Support
+--------------------
+spr supports [Jujutsu](https://jj-vcs.github.io/jj/) colocated repositories. When spr detects a `.jj/` directory in your repo root, it automatically uses jj-native commands for history-rewriting operations (`jj describe`, `jj rebase`, `jj squash`, `jj edit`) instead of `git rebase`. This preserves jj change IDs across all spr operations.
+
+Everything else (push, branch management, GitHub API calls) continues to use git, which works identically in colocated repos.
+
+**Setup:**
+```shell
+# 1. Initialize jj in your existing git repo (if not already)
+jj git init --colocate
+
+# 2. Register the jj alias so you can use "jj spr" instead of "git spr"
+git spr jj-setup
+```
+
+The `jj-setup` command adds a jj alias so spr can be invoked as `jj spr`:
+```shell
+jj spr update          # create/update PRs
+jj spr status          # show PR status
+jj spr merge           # merge PRs
+jj spr amend           # amend a commit in the stack
+```
+
+You can also set up the alias manually:
+```shell
+jj config set --user aliases.spr '["util", "exec", "--", "git-spr"]'
+```
+
+**Opt-out:** If you have a `.jj/` directory but want spr to use git mode:
+- CLI flag: `jj spr update --no-jj`
+- Environment variable: `SPR_NOJJ=true`
+- Config: add `noJJ: true` to `~/.spr.yml`
 
 Happy Coding!
 -------------

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,14 +20,23 @@ import (
 	"github.com/ejoffe/spr/config/config_parser"
 	"github.com/ejoffe/spr/git"
 	"github.com/ejoffe/spr/github"
+	"github.com/ejoffe/spr/vcs"
 )
 
 // NewStackedPR constructs and returns a new stackediff instance.
-func NewStackedPR(config *config.Config, github github.GitHubInterface, gitcmd git.GitInterface) *stackediff {
+// If vcsOps is nil, a default git-based implementation is created.
+func NewStackedPR(config *config.Config, github github.GitHubInterface, gitcmd git.GitInterface, vcsOps ...vcs.VCSOperations) *stackediff {
+	var ops vcs.VCSOperations
+	if len(vcsOps) > 0 && vcsOps[0] != nil {
+		ops = vcsOps[0]
+	} else {
+		ops = vcs.NewGitOps(config, gitcmd)
+	}
 	return &stackediff{
 		config:       config,
 		github:       github,
 		gitcmd:       gitcmd,
+		vcsOps:       ops,
 		profiletimer: profiletimer.StartNoopTimer(),
 
 		output: os.Stdout,
@@ -40,6 +48,7 @@ type stackediff struct {
 	config        *config.Config
 	github        github.GitHubInterface
 	gitcmd        git.GitInterface
+	vcsOps        vcs.VCSOperations
 	profiletimer  profiletimer.Timer
 	DetailEnabled bool
 
@@ -52,7 +61,7 @@ type stackediff struct {
 //
 //	of commits. A list of commits is printed and one can be chosen to be amended.
 func (sd *stackediff) AmendCommit(ctx context.Context) {
-	localCommits := git.GetLocalCommitStack(sd.config, sd.gitcmd)
+	localCommits := sd.vcsOps.GetLocalCommitStack(sd.config, sd.gitcmd)
 	if len(localCommits) == 0 {
 		fmt.Fprintf(sd.output, "No commits to amend\n")
 		return
@@ -79,20 +88,16 @@ func (sd *stackediff) AmendCommit(ctx context.Context) {
 	}
 	commitIndex = commitIndex - 1
 	check(err)
-	sd.gitcmd.MustGit("commit --fixup "+localCommits[commitIndex].CommitHash, nil)
-
-	rebaseCmd := fmt.Sprintf("rebase -i --autosquash --autostash %s/%s",
-		sd.config.Repo.GitHubRemote, sd.config.Repo.GitHubBranch)
-	sd.gitcmd.MustGit(rebaseCmd, nil)
+	err = sd.vcsOps.AmendInto(localCommits[commitIndex])
+	check(err)
 }
 
 func (sd *stackediff) editStatePath() string {
-	return filepath.Join(sd.gitcmd.RootDir(), ".git", "spr_edit_state")
+	return sd.vcsOps.EditStatePath()
 }
 
 func (sd *stackediff) isEditing() bool {
-	_, err := os.Stat(sd.editStatePath())
-	return err == nil
+	return sd.vcsOps.IsEditing()
 }
 
 // EditCommit starts an interactive edit session on a commit in the stack.
@@ -107,7 +112,7 @@ func (sd *stackediff) EditCommit(ctx context.Context) {
 		return
 	}
 
-	localCommits := git.GetLocalCommitStack(sd.config, sd.gitcmd)
+	localCommits := sd.vcsOps.GetLocalCommitStack(sd.config, sd.gitcmd)
 	if len(localCommits) == 0 {
 		fmt.Fprintf(sd.output, "No commits to edit\n")
 		return
@@ -136,23 +141,8 @@ func (sd *stackediff) EditCommit(ctx context.Context) {
 
 	targetCommit := localCommits[commitIndex]
 
-	// Write state file so --done knows we're in an edit session
-	stateContent := fmt.Sprintf("commit_id=%s\ncommit_subject=%s\n", targetCommit.CommitID, targetCommit.Subject)
-	err = os.WriteFile(sd.editStatePath(), []byte(stateContent), 0644)
-	check(err)
-
-	// Use the spr binary itself as the sequence editor to rewrite 'pick' to 'edit'
-	// for the target commit. Git invokes the editor as: <editor> <todo-file>
-	exe, err := os.Executable()
-	check(err)
-	editorCmd := fmt.Sprintf("%s _edit-sequence %s", exe, targetCommit.CommitHash[:7])
-
-	rebaseCmd := fmt.Sprintf("rebase -i --autostash %s/%s",
-		sd.config.Repo.GitHubRemote, sd.config.Repo.GitHubBranch)
-	err = sd.gitcmd.GitWithEditor(rebaseCmd, nil, editorCmd)
+	err = sd.vcsOps.EditStart(targetCommit)
 	if err != nil {
-		// Clean up state file on failure
-		os.Remove(sd.editStatePath())
 		fmt.Fprintf(sd.output, "Failed to start edit session: %s\n", err)
 		return
 	}
@@ -171,26 +161,13 @@ func (sd *stackediff) EditCommitDone(ctx context.Context, update bool) {
 		return
 	}
 
-	// Stage all changes
-	sd.gitcmd.MustGit("add -A", nil)
-
-	// Amend the current commit (no-edit keeps the original message)
-	err := sd.gitcmd.Git("commit --amend --no-edit", nil)
+	err := sd.vcsOps.EditFinish()
 	if err != nil {
-		fmt.Fprintf(sd.output, "Failed to amend commit: %s\n", err)
+		fmt.Fprintf(sd.output, "Edit finish failed: %s\n", err)
 		fmt.Fprintf(sd.output, "Resolve any issues and try again.\n")
 		return
 	}
 
-	// Continue the rebase to replay the remaining commits
-	err = sd.gitcmd.Git("rebase --continue", nil)
-	if err != nil {
-		fmt.Fprintf(sd.output, "Rebase conflict detected. Resolve conflicts and run 'git spr edit --done' again.\n")
-		return
-	}
-
-	// Clean up state file
-	os.Remove(sd.editStatePath())
 	fmt.Fprintf(sd.output, "Stack restored successfully.\n")
 
 	if update {
@@ -205,13 +182,12 @@ func (sd *stackediff) EditCommitAbort(ctx context.Context) {
 		return
 	}
 
-	err := sd.gitcmd.Git("rebase --abort", nil)
+	err := sd.vcsOps.EditAbort()
 	if err != nil {
 		fmt.Fprintf(sd.output, "Failed to abort: %s\n", err)
 		return
 	}
 
-	os.Remove(sd.editStatePath())
 	fmt.Fprintf(sd.output, "Edit session aborted.\n")
 }
 
@@ -271,7 +247,7 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context, reviewers []string
 		return
 	}
 	sd.profiletimer.Step("UpdatePullRequests::FetchAndGetGitHubInfo")
-	localCommits := alignLocalCommits(git.GetLocalCommitStack(sd.config, sd.gitcmd), githubInfo.PullRequests)
+	localCommits := alignLocalCommits(sd.vcsOps.GetLocalCommitStack(sd.config, sd.gitcmd), githubInfo.PullRequests)
 	sd.profiletimer.Step("UpdatePullRequests::GetLocalCommitStack")
 
 	// close prs for deleted commits
@@ -623,14 +599,7 @@ func sortPullRequestsByLocalCommitOrder(pullRequests []*github.PullRequest, loca
 }
 
 func (sd *stackediff) fetchAndGetGitHubInfo(ctx context.Context) *github.GitHubInfo {
-	if sd.config.Repo.ForceFetchTags {
-		sd.gitcmd.MustGit("fetch --tags --force", nil)
-	} else {
-		sd.gitcmd.MustGit("fetch", nil)
-	}
-	rebaseCommand := fmt.Sprintf("rebase %s/%s --autostash",
-		sd.config.Repo.GitHubRemote, sd.config.Repo.GitHubBranch)
-	err := sd.gitcmd.Git(rebaseCommand, nil)
+	err := sd.vcsOps.FetchAndRebase(sd.config)
 	if err != nil {
 		return nil
 	}
@@ -655,15 +624,11 @@ func (sd *stackediff) fetchAndGetGitHubInfo(ctx context.Context) *github.GitHubI
 func (sd *stackediff) syncCommitStackToGitHub(ctx context.Context,
 	commits []git.Commit, info *github.GitHubInfo,
 ) bool {
-	var output string
-	sd.gitcmd.MustGit("status --porcelain --untracked-files=no", &output)
-	if output != "" {
-		err := sd.gitcmd.Git("stash", nil)
-		if err != nil {
-			return false
-		}
-		defer sd.gitcmd.MustGit("stash pop", nil)
+	cleanup, err := sd.vcsOps.PrepareForPush()
+	if err != nil {
+		return false
 	}
+	defer cleanup()
 
 	commitUpdated := func(c git.Commit, info *github.GitHubInfo) bool {
 		for _, pr := range info.PullRequests {

--- a/vcs/detect.go
+++ b/vcs/detect.go
@@ -1,0 +1,13 @@
+package vcs
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// IsJJColocated returns true if the repository at rootDir is a jj-colocated
+// repo (has both .jj/ and .git/ directories).
+func IsJJColocated(rootDir string) bool {
+	_, err := os.Stat(filepath.Join(rootDir, ".jj"))
+	return err == nil
+}

--- a/vcs/detect_test.go
+++ b/vcs/detect_test.go
@@ -1,0 +1,70 @@
+package vcs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ejoffe/spr/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsJJColocated_NoJJDir(t *testing.T) {
+	dir := t.TempDir()
+	require.False(t, IsJJColocated(dir))
+}
+
+func TestIsJJColocated_WithJJDir(t *testing.T) {
+	dir := t.TempDir()
+	err := os.Mkdir(filepath.Join(dir, ".jj"), 0755)
+	require.NoError(t, err)
+	require.True(t, IsJJColocated(dir))
+}
+
+func TestIsJJColocated_EmptyString(t *testing.T) {
+	require.False(t, IsJJColocated(""))
+}
+
+func TestNewVCSOperations_GitRepo(t *testing.T) {
+	cfg := config.EmptyConfig()
+	dir := t.TempDir()
+	gitmock := &mockRootDirOnly{rootDir: dir}
+	ops := NewVCSOperations(cfg, gitmock)
+	_, isGit := ops.(*GitOps)
+	require.True(t, isGit, "should return GitOps for non-jj repo")
+}
+
+func TestNewVCSOperations_JJRepo(t *testing.T) {
+	cfg := config.EmptyConfig()
+	dir := t.TempDir()
+	os.Mkdir(filepath.Join(dir, ".jj"), 0755)
+	gitmock := &mockRootDirOnly{rootDir: dir}
+	ops := NewVCSOperations(cfg, gitmock)
+	_, isJj := ops.(*JjOps)
+	require.True(t, isJj, "should return JjOps for jj-colocated repo")
+}
+
+func TestNewVCSOperations_JJRepo_NoJJFlag(t *testing.T) {
+	cfg := config.EmptyConfig()
+	cfg.User.NoJJ = true
+	dir := t.TempDir()
+	os.Mkdir(filepath.Join(dir, ".jj"), 0755)
+	gitmock := &mockRootDirOnly{rootDir: dir}
+	ops := NewVCSOperations(cfg, gitmock)
+	_, isGit := ops.(*GitOps)
+	require.True(t, isGit, "should return GitOps when NoJJ is true even with .jj/ present")
+}
+
+// mockRootDirOnly implements git.GitInterface with only RootDir meaningful.
+type mockRootDirOnly struct {
+	rootDir string
+}
+
+func (m *mockRootDirOnly) GitWithEditor(args string, output *string, editorCmd string) error {
+	return nil
+}
+func (m *mockRootDirOnly) Git(args string, output *string) error                             { return nil }
+func (m *mockRootDirOnly) MustGit(args string, output *string)                               {}
+func (m *mockRootDirOnly) RootDir() string                                                   { return m.rootDir }
+func (m *mockRootDirOnly) DeleteRemoteBranch(ctx context.Context, branch string) error       { return nil }

--- a/vcs/git_ops.go
+++ b/vcs/git_ops.go
@@ -1,0 +1,133 @@
+package vcs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ejoffe/spr/config"
+	"github.com/ejoffe/spr/git"
+)
+
+// GitOps implements VCSOperations using standard git commands.
+// This is a pure extraction of the existing logic from spr.go and helpers.go.
+type GitOps struct {
+	cfg    *config.Config
+	gitcmd git.GitInterface
+}
+
+// NewGitOps creates a git-based VCSOperations implementation.
+func NewGitOps(cfg *config.Config, gitcmd git.GitInterface) *GitOps {
+	return &GitOps{cfg: cfg, gitcmd: gitcmd}
+}
+
+// FetchAndRebase fetches from remote and rebases the local stack.
+// Extracted from spr.go fetchAndGetGitHubInfo().
+func (g *GitOps) FetchAndRebase(cfg *config.Config) error {
+	if cfg.Repo.ForceFetchTags {
+		g.gitcmd.MustGit("fetch --tags --force", nil)
+	} else {
+		g.gitcmd.MustGit("fetch", nil)
+	}
+	rebaseCommand := fmt.Sprintf("rebase %s/%s --autostash",
+		cfg.Repo.GitHubRemote, cfg.Repo.GitHubBranch)
+	return g.gitcmd.Git(rebaseCommand, nil)
+}
+
+// GetLocalCommitStack returns the local commit stack using git log.
+// Delegates to the existing git.GetLocalCommitStack function.
+func (g *GitOps) GetLocalCommitStack(cfg *config.Config, gitcmd git.GitInterface) []git.Commit {
+	return git.GetLocalCommitStack(cfg, gitcmd)
+}
+
+// AmendInto creates a fixup commit and autosquashes it into the target.
+// Extracted from spr.go AmendCommit().
+func (g *GitOps) AmendInto(commit git.Commit) error {
+	g.gitcmd.MustGit("commit --fixup "+commit.CommitHash, nil)
+	rebaseCmd := fmt.Sprintf("rebase -i --autosquash --autostash %s/%s",
+		g.cfg.Repo.GitHubRemote, g.cfg.Repo.GitHubBranch)
+	g.gitcmd.MustGit(rebaseCmd, nil)
+	return nil
+}
+
+// EditStart begins an interactive edit session on a commit.
+// Extracted from spr.go EditCommit().
+func (g *GitOps) EditStart(commit git.Commit) error {
+	// Write state file
+	stateContent := fmt.Sprintf("commit_id=%s\ncommit_subject=%s\n", commit.CommitID, commit.Subject)
+	err := os.WriteFile(g.EditStatePath(), []byte(stateContent), 0644)
+	if err != nil {
+		return err
+	}
+
+	// Use the spr binary as the sequence editor to rewrite 'pick' to 'edit'
+	exe, err := os.Executable()
+	if err != nil {
+		os.Remove(g.EditStatePath())
+		return err
+	}
+	editorCmd := fmt.Sprintf("%s _edit-sequence %s", exe, commit.CommitHash[:7])
+
+	rebaseCmd := fmt.Sprintf("rebase -i --autostash %s/%s",
+		g.cfg.Repo.GitHubRemote, g.cfg.Repo.GitHubBranch)
+	err = g.gitcmd.GitWithEditor(rebaseCmd, nil, editorCmd)
+	if err != nil {
+		os.Remove(g.EditStatePath())
+		return err
+	}
+	return nil
+}
+
+// EditFinish completes an edit session by amending and continuing the rebase.
+// Extracted from spr.go EditCommitDone().
+func (g *GitOps) EditFinish() error {
+	g.gitcmd.MustGit("add -A", nil)
+	err := g.gitcmd.Git("commit --amend --no-edit", nil)
+	if err != nil {
+		return fmt.Errorf("failed to amend commit: %w", err)
+	}
+	err = g.gitcmd.Git("rebase --continue", nil)
+	if err != nil {
+		return fmt.Errorf("rebase conflict detected: %w", err)
+	}
+	os.Remove(g.EditStatePath())
+	return nil
+}
+
+// EditAbort cancels the current edit session.
+// Extracted from spr.go EditCommitAbort().
+func (g *GitOps) EditAbort() error {
+	err := g.gitcmd.Git("rebase --abort", nil)
+	if err != nil {
+		return fmt.Errorf("failed to abort rebase: %w", err)
+	}
+	os.Remove(g.EditStatePath())
+	return nil
+}
+
+// PrepareForPush stashes uncommitted changes and returns a cleanup function.
+// Extracted from spr.go syncCommitStackToGitHub().
+func (g *GitOps) PrepareForPush() (func(), error) {
+	var output string
+	g.gitcmd.MustGit("status --porcelain --untracked-files=no", &output)
+	if output != "" {
+		err := g.gitcmd.Git("stash", nil)
+		if err != nil {
+			return nil, err
+		}
+		return func() { g.gitcmd.MustGit("stash pop", nil) }, nil
+	}
+	return func() {}, nil
+}
+
+// IsEditing returns true if an edit session is in progress.
+func (g *GitOps) IsEditing() bool {
+	_, err := os.Stat(g.EditStatePath())
+	return err == nil
+}
+
+// EditStatePath returns the path to the edit state file.
+func (g *GitOps) EditStatePath() string {
+	return filepath.Join(g.gitcmd.RootDir(), ".git", "spr_edit_state")
+}
+

--- a/vcs/git_ops_test.go
+++ b/vcs/git_ops_test.go
@@ -1,0 +1,76 @@
+package vcs
+
+import (
+	"testing"
+
+	"github.com/ejoffe/spr/config"
+	"github.com/ejoffe/spr/git/mockgit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeGitTestConfig() *config.Config {
+	cfg := config.EmptyConfig()
+	cfg.Repo.GitHubRemote = "origin"
+	cfg.Repo.GitHubBranch = "master"
+	cfg.Repo.MergeMethod = "rebase"
+	return cfg
+}
+
+func TestGitOpsFetchAndRebase(t *testing.T) {
+	cfg := makeGitTestConfig()
+	gitmock := mockgit.NewMockGit(t)
+	ops := NewGitOps(cfg, gitmock)
+
+	gitmock.ExpectFetch() // expects git fetch + git rebase origin/master --autostash
+
+	err := ops.FetchAndRebase(cfg)
+	require.NoError(t, err)
+	gitmock.ExpectationsMet()
+}
+
+func TestGitOpsFetchAndRebase_ForceTags(t *testing.T) {
+	cfg := makeGitTestConfig()
+	cfg.Repo.ForceFetchTags = true
+	gitmock := mockgit.NewMockGit(t)
+	ops := NewGitOps(cfg, gitmock)
+
+	// ExpectFetch expects "git fetch" but with force tags it's "git fetch --tags --force"
+	// We need a custom expectation
+	gitmock.ExpectFetchTags()
+
+	err := ops.FetchAndRebase(cfg)
+	require.NoError(t, err)
+	gitmock.ExpectationsMet()
+}
+
+func TestGitOpsPrepareForPush_Clean(t *testing.T) {
+	cfg := makeGitTestConfig()
+	gitmock := mockgit.NewMockGit(t)
+	ops := NewGitOps(cfg, gitmock)
+
+	gitmock.ExpectStatus() // returns empty (clean)
+
+	cleanup, err := ops.PrepareForPush()
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup() // should not panic, no stash pop expected
+	gitmock.ExpectationsMet()
+}
+
+func TestGitOpsIsEditing_NoStateFile(t *testing.T) {
+	cfg := makeGitTestConfig()
+	gitmock := mockgit.NewMockGit(t)
+	ops := NewGitOps(cfg, gitmock)
+
+	assert.False(t, ops.IsEditing())
+}
+
+func TestGitOpsEditStatePath(t *testing.T) {
+	cfg := makeGitTestConfig()
+	gitmock := mockgit.NewMockGit(t)
+	ops := NewGitOps(cfg, gitmock)
+
+	// mockgit.RootDir() returns ""
+	assert.Contains(t, ops.EditStatePath(), "spr_edit_state")
+}

--- a/vcs/interface.go
+++ b/vcs/interface.go
@@ -1,0 +1,64 @@
+package vcs
+
+import (
+	"github.com/ejoffe/spr/config"
+	"github.com/ejoffe/spr/git"
+)
+
+// VCSOperations abstracts the version control operations that differ between
+// git and jj (Jujutsu). Operations like push, fetch, and branch management
+// stay on git.GitInterface; only history-rewriting operations are abstracted here.
+type VCSOperations interface {
+	// FetchAndRebase fetches from remote and rebases local stack onto updated trunk.
+	// Git: git fetch + git rebase origin/main --autostash
+	// jj:  jj git fetch + jj rebase -b @ -d main@origin
+	FetchAndRebase(cfg *config.Config) error
+
+	// GetLocalCommitStack returns unmerged commits (bottom-first), adding
+	// commit-id trailers if missing.
+	// Git: git log origin/main..HEAD, then git rebase -i with spr_reword_helper if needed
+	// jj:  jj log -r 'trunk()..@' --reversed, then jj describe for missing trailers
+	GetLocalCommitStack(cfg *config.Config, gitcmd git.GitInterface) []git.Commit
+
+	// AmendInto squashes working copy changes into a specific commit in the stack.
+	// Git: git commit --fixup <hash> + git rebase -i --autosquash --autostash
+	// jj:  jj squash --into <change-id>
+	AmendInto(commit git.Commit) error
+
+	// EditStart checks out a commit for editing (interactive edit session).
+	// Git: git rebase -i with 'edit' stop
+	// jj:  jj edit <change-id>
+	EditStart(commit git.Commit) error
+
+	// EditFinish completes an edit session.
+	// Git: git add -A + git commit --amend --no-edit + git rebase --continue
+	// jj:  jj new <original-@> (changes are auto-captured)
+	EditFinish() error
+
+	// EditAbort cancels an edit session.
+	// Git: git rebase --abort
+	// jj:  jj op restore <saved-op-id>
+	EditAbort() error
+
+	// PrepareForPush saves working state before push and returns a cleanup func.
+	// Git: git stash / git stash pop
+	// jj:  no-op (working copy is always a commit)
+	PrepareForPush() (cleanup func(), err error)
+
+	// IsEditing returns true if an edit session is in progress.
+	IsEditing() bool
+
+	// EditStatePath returns the path to the edit state file.
+	EditStatePath() string
+}
+
+// NewVCSOperations creates a VCSOperations implementation appropriate for the
+// current repository. If a .jj/ directory exists (jj-colocated repo) and
+// the user has not set noJJ, returns a jj implementation.
+// Otherwise returns a git implementation.
+func NewVCSOperations(cfg *config.Config, gitcmd git.GitInterface) VCSOperations {
+	if !cfg.User.NoJJ && IsJJColocated(gitcmd.RootDir()) {
+		return NewJjOps(cfg, NewJjCmd(gitcmd.RootDir()), gitcmd)
+	}
+	return NewGitOps(cfg, gitcmd)
+}

--- a/vcs/jj_cmd.go
+++ b/vcs/jj_cmd.go
@@ -1,0 +1,70 @@
+package vcs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// JjCmd executes jj commands, mirroring the git/realgit/realcmd.go pattern.
+type JjCmd struct {
+	rootdir string
+}
+
+// NewJjCmd creates a new jj command executor.
+func NewJjCmd(rootDir string) *JjCmd {
+	return &JjCmd{rootdir: rootDir}
+}
+
+// JjInterface abstracts jj command execution for testing.
+type JjInterface interface {
+	Jj(args string, output *string) error
+	MustJj(args string, output *string)
+	JjArgs(args []string, output *string) error
+}
+
+// Jj executes a jj command with the given arguments.
+func (c *JjCmd) Jj(args string, output *string) error {
+	log.Debug().Msgf("jj %s", args)
+	cmdArgs := strings.Fields(args)
+	cmd := exec.Command("jj", cmdArgs...)
+	cmd.Dir = c.rootdir
+	cmd.Env = append(os.Environ(), "JJ_CONFIG=")
+
+	out, err := cmd.CombinedOutput()
+	if output != nil {
+		*output = strings.TrimRight(string(out), "\n")
+	}
+	if err != nil {
+		return fmt.Errorf("jj %s: %w\n%s", args, err, string(out))
+	}
+	return nil
+}
+
+// MustJj executes a jj command and panics on error.
+func (c *JjCmd) MustJj(args string, output *string) {
+	err := c.Jj(args, output)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// JjArgs executes a jj command with pre-split arguments (for messages with spaces).
+func (c *JjCmd) JjArgs(args []string, output *string) error {
+	log.Debug().Msgf("jj %v", args)
+	cmd := exec.Command("jj", args...)
+	cmd.Dir = c.rootdir
+	cmd.Env = append(os.Environ(), "JJ_CONFIG=")
+
+	out, err := cmd.CombinedOutput()
+	if output != nil {
+		*output = strings.TrimRight(string(out), "\n")
+	}
+	if err != nil {
+		return fmt.Errorf("jj %v: %w\n%s", args, err, string(out))
+	}
+	return nil
+}

--- a/vcs/jj_ops.go
+++ b/vcs/jj_ops.go
@@ -1,0 +1,210 @@
+package vcs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ejoffe/spr/config"
+	"github.com/ejoffe/spr/git"
+	"github.com/google/uuid"
+)
+
+// JjOps implements VCSOperations using jj (Jujutsu) commands.
+// Git commands are still used for push operations (via gitcmd).
+type JjOps struct {
+	cfg    *config.Config
+	jjcmd  JjInterface
+	gitcmd git.GitInterface
+}
+
+// NewJjOps creates a jj-based VCSOperations implementation.
+func NewJjOps(cfg *config.Config, jjcmd JjInterface, gitcmd git.GitInterface) *JjOps {
+	return &JjOps{cfg: cfg, jjcmd: jjcmd, gitcmd: gitcmd}
+}
+
+// FetchAndRebase fetches from remote and rebases using jj commands.
+// Preserves jj change IDs (unlike git rebase which destroys them).
+func (j *JjOps) FetchAndRebase(cfg *config.Config) error {
+	if cfg.User.NoRebase {
+		// Only fetch, skip rebase (same semantics as git NoRebase)
+		return j.jjcmd.Jj("git fetch", nil)
+	}
+
+	err := j.jjcmd.Jj("git fetch", nil)
+	if err != nil {
+		return err
+	}
+
+	// Rebase current stack onto updated trunk
+	remote := cfg.Repo.GitHubRemote
+	branch := cfg.Repo.GitHubBranch
+	rebaseCmd := fmt.Sprintf("rebase -b @ -d %s@%s", branch, remote)
+	return j.jjcmd.Jj(rebaseCmd, nil)
+}
+
+// GetLocalCommitStack returns unmerged commits using jj log.
+// If any commits lack commit-id trailers, adds them via jj describe.
+func (j *JjOps) GetLocalCommitStack(cfg *config.Config, gitcmd git.GitInterface) []git.Commit {
+	template := `commit_id ++ "\x1f" ++ change_id ++ "\x1f" ++ empty ++ "\x1f" ++ description ++ "\x1e"`
+	logCmd := fmt.Sprintf(`log --no-graph --reversed --color=never -r "trunk()..@" -T '%s'`, template)
+
+	var output string
+	j.jjcmd.MustJj(logCmd, &output)
+
+	parsed, valid := parseJjLogOutput(output)
+
+	if !valid {
+		// Add commit-id trailers to commits that lack them
+		for i, p := range parsed {
+			if p.sprCommitID == "" && !p.empty {
+				newID := uuid.New().String()[:8]
+				newDesc := strings.TrimRight(p.description, "\n")
+				newDesc += "\n\ncommit-id:" + newID
+				err := j.jjcmd.JjArgs([]string{"describe", "-r", p.changeID, "-m", newDesc}, nil)
+				if err != nil {
+					panic(fmt.Sprintf("failed to add commit-id to %s: %v", p.changeID, err))
+				}
+				parsed[i].sprCommitID = newID
+			}
+		}
+
+		// Re-read commit hashes since jj describe changes them
+		j.jjcmd.MustJj(logCmd, &output)
+		reparsed, revalid := parseJjLogOutput(output)
+		if !revalid {
+			panic("unable to add commit-id trailers via jj describe")
+		}
+		parsed = reparsed
+	}
+
+	// Convert to []git.Commit
+	var commits []git.Commit
+	for _, p := range parsed {
+		if p.wip {
+			// Include WIP commits but mark them (spr stops at first WIP)
+		}
+		commits = append(commits, git.Commit{
+			CommitID:   p.sprCommitID,
+			CommitHash: p.commitHash,
+			ChangeID:   p.changeID,
+			Subject:    p.subject,
+			Body:       p.body,
+			WIP:        p.wip,
+		})
+	}
+	return commits
+}
+
+// AmendInto squashes working copy changes into a specific commit.
+// Uses jj squash which preserves change IDs.
+func (j *JjOps) AmendInto(commit git.Commit) error {
+	if commit.ChangeID == "" {
+		return fmt.Errorf("cannot amend: commit %s has no jj change ID", commit.CommitID)
+	}
+	return j.jjcmd.Jj(fmt.Sprintf("squash --into %s", commit.ChangeID), nil)
+}
+
+// EditStart begins an edit session by checking out the target commit.
+// Uses jj edit which preserves change IDs.
+func (j *JjOps) EditStart(commit git.Commit) error {
+	if commit.ChangeID == "" {
+		return fmt.Errorf("cannot edit: commit %s has no jj change ID", commit.CommitID)
+	}
+
+	// Save operation ID for abort
+	var opID string
+	j.jjcmd.MustJj("op log --no-graph -n 1 -T 'id.short(16)'", &opID)
+
+	// Save current @ for finish
+	var currentAt string
+	j.jjcmd.MustJj("log --no-graph -r @ -T change_id", &currentAt)
+
+	// Write state file
+	stateContent := fmt.Sprintf("vcs=jj\nchange_id=%s\noriginal_at=%s\nop_id=%s\ncommit_id=%s\ncommit_subject=%s\n",
+		commit.ChangeID, strings.TrimSpace(currentAt), strings.TrimSpace(opID),
+		commit.CommitID, commit.Subject)
+	err := os.WriteFile(j.EditStatePath(), []byte(stateContent), 0644)
+	if err != nil {
+		return err
+	}
+
+	// Move working copy to the target commit
+	err = j.jjcmd.Jj("edit "+commit.ChangeID, nil)
+	if err != nil {
+		os.Remove(j.EditStatePath())
+		return err
+	}
+	return nil
+}
+
+// EditFinish completes an edit session.
+// In jj, changes to the edited commit are automatically captured.
+// We just need to return to where we were.
+func (j *JjOps) EditFinish() error {
+	state, err := j.readEditState()
+	if err != nil {
+		return err
+	}
+
+	// Return to where we were before the edit
+	err = j.jjcmd.Jj("new "+state["original_at"], nil)
+	if err != nil {
+		return fmt.Errorf("failed to return from edit: %w", err)
+	}
+
+	os.Remove(j.EditStatePath())
+	return nil
+}
+
+// EditAbort cancels an edit session by restoring the operation state.
+func (j *JjOps) EditAbort() error {
+	state, err := j.readEditState()
+	if err != nil {
+		return err
+	}
+
+	err = j.jjcmd.Jj("op restore "+state["op_id"], nil)
+	if err != nil {
+		return fmt.Errorf("failed to restore operation: %w", err)
+	}
+
+	os.Remove(j.EditStatePath())
+	return nil
+}
+
+// PrepareForPush is a no-op for jj — the working copy is always a commit.
+func (j *JjOps) PrepareForPush() (func(), error) {
+	return func() {}, nil
+}
+
+// IsEditing returns true if an edit session is in progress.
+func (j *JjOps) IsEditing() bool {
+	_, err := os.Stat(j.EditStatePath())
+	return err == nil
+}
+
+// EditStatePath returns the path to the edit state file.
+func (j *JjOps) EditStatePath() string {
+	if j.gitcmd != nil {
+		return filepath.Join(j.gitcmd.RootDir(), ".git", "spr_edit_state")
+	}
+	return ""
+}
+
+// readEditState reads the key=value state file.
+func (j *JjOps) readEditState() (map[string]string, error) {
+	data, err := os.ReadFile(j.EditStatePath())
+	if err != nil {
+		return nil, fmt.Errorf("no edit session in progress: %w", err)
+	}
+	state := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			state[parts[0]] = parts[1]
+		}
+	}
+	return state, nil
+}

--- a/vcs/jj_ops_test.go
+++ b/vcs/jj_ops_test.go
@@ -1,0 +1,260 @@
+package vcs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ejoffe/spr/config"
+	"github.com/ejoffe/spr/git"
+	"github.com/ejoffe/spr/git/mockgit"
+	"github.com/ejoffe/spr/vcs/mockjj"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeJjTestConfig() *config.Config {
+	cfg := config.EmptyConfig()
+	cfg.Repo.GitHubRemote = "origin"
+	cfg.Repo.GitHubBranch = "main"
+	cfg.Repo.MergeMethod = "squash"
+	return cfg
+}
+
+// --- FetchAndRebase ---
+
+func TestJjOpsFetchAndRebase(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	jjmock.ExpectFetch()
+	jjmock.ExpectRebase("origin", "main")
+
+	err := ops.FetchAndRebase(cfg)
+	require.NoError(t, err)
+	jjmock.ExpectationsMet()
+}
+
+func TestJjOpsFetchAndRebase_NoRebase(t *testing.T) {
+	cfg := makeJjTestConfig()
+	cfg.User.NoRebase = true
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	// Only fetch, no rebase
+	jjmock.ExpectFetch()
+
+	err := ops.FetchAndRebase(cfg)
+	require.NoError(t, err)
+	jjmock.ExpectationsMet()
+}
+
+// --- GetLocalCommitStack ---
+
+func TestJjOpsGetLocalCommitStack_AllHaveIDs(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	c1 := &git.Commit{
+		CommitID:   "00000001",
+		CommitHash: "c100000000000000000000000000000000000000",
+		ChangeID:   "jjchange1",
+		Subject:    "test commit 1",
+	}
+	c2 := &git.Commit{
+		CommitID:   "00000002",
+		CommitHash: "c200000000000000000000000000000000000000",
+		ChangeID:   "jjchange2",
+		Subject:    "test commit 2",
+	}
+
+	jjmock.ExpectLogAndRespond([]*git.Commit{c1, c2})
+
+	commits := ops.GetLocalCommitStack(cfg, nil)
+	require.Len(t, commits, 2)
+	assert.Equal(t, "00000001", commits[0].CommitID)
+	assert.Equal(t, "jjchange1", commits[0].ChangeID)
+	assert.Equal(t, "00000002", commits[1].CommitID)
+	assert.Equal(t, "jjchange2", commits[1].ChangeID)
+	jjmock.ExpectationsMet()
+}
+
+func TestJjOpsGetLocalCommitStack_WIPCommit(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	c1 := &git.Commit{
+		CommitID:   "00000001",
+		CommitHash: "c100000000000000000000000000000000000000",
+		ChangeID:   "jjchange1",
+		Subject:    "WIP not ready yet",
+	}
+
+	jjmock.ExpectLogAndRespond([]*git.Commit{c1})
+
+	commits := ops.GetLocalCommitStack(cfg, nil)
+	require.Len(t, commits, 1)
+	assert.True(t, commits[0].WIP)
+	jjmock.ExpectationsMet()
+}
+
+// --- AmendInto ---
+
+func TestJjOpsAmendInto(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	commit := git.Commit{
+		CommitID:   "00000001",
+		CommitHash: "c100000000000000000000000000000000000000",
+		ChangeID:   "jjchange1",
+	}
+
+	jjmock.ExpectSquash("jjchange1")
+
+	err := ops.AmendInto(commit)
+	require.NoError(t, err)
+	jjmock.ExpectationsMet()
+}
+
+func TestJjOpsAmendInto_NoChangeID(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	commit := git.Commit{
+		CommitID:   "00000001",
+		CommitHash: "c100000000000000000000000000000000000000",
+		// No ChangeID
+	}
+
+	err := ops.AmendInto(commit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no jj change ID")
+	jjmock.ExpectationsMet()
+}
+
+// --- EditStart / EditFinish / EditAbort ---
+
+func TestJjOpsEditStart(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	gitmock := mockgit.NewMockGit(t)
+	ops := NewJjOps(cfg, jjmock, gitmock)
+
+	// Create a temp dir so EditStatePath works
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	os.Mkdir(gitDir, 0755)
+	// Override gitcmd.RootDir to use tmpDir
+	ops.gitcmd = &mockRootDir{rootDir: tmpDir}
+
+	commit := git.Commit{
+		CommitID:   "00000001",
+		CommitHash: "c100000000000000000000000000000000000000",
+		ChangeID:   "jjchange1",
+		Subject:    "test commit 1",
+	}
+
+	jjmock.ExpectOpLog("op123456abcdef")
+	jjmock.ExpectLogAt("currentchange")
+	jjmock.ExpectEdit("jjchange1")
+
+	err := ops.EditStart(commit)
+	require.NoError(t, err)
+	assert.True(t, ops.IsEditing())
+
+	// Verify state file contents
+	data, err := os.ReadFile(ops.EditStatePath())
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "original_at=currentchange")
+	assert.Contains(t, string(data), "op_id=op123456abcdef")
+	assert.Contains(t, string(data), "change_id=jjchange1")
+
+	jjmock.ExpectationsMet()
+}
+
+func TestJjOpsEditFinish(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	// Create state file manually
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	os.Mkdir(gitDir, 0755)
+	ops.gitcmd = &mockRootDir{rootDir: tmpDir}
+
+	stateContent := "vcs=jj\nchange_id=jjchange1\noriginal_at=prevchange\nop_id=op123456\ncommit_id=00000001\n"
+	os.WriteFile(ops.EditStatePath(), []byte(stateContent), 0644)
+
+	jjmock.ExpectNew("prevchange")
+
+	err := ops.EditFinish()
+	require.NoError(t, err)
+	assert.False(t, ops.IsEditing()) // state file cleaned up
+	jjmock.ExpectationsMet()
+}
+
+func TestJjOpsEditAbort(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	os.Mkdir(gitDir, 0755)
+	ops.gitcmd = &mockRootDir{rootDir: tmpDir}
+
+	stateContent := "vcs=jj\nchange_id=jjchange1\noriginal_at=prevchange\nop_id=op123456\ncommit_id=00000001\n"
+	os.WriteFile(ops.EditStatePath(), []byte(stateContent), 0644)
+
+	jjmock.ExpectOpRestore("op123456")
+
+	err := ops.EditAbort()
+	require.NoError(t, err)
+	assert.False(t, ops.IsEditing())
+	jjmock.ExpectationsMet()
+}
+
+func TestJjOpsEditStart_NoChangeID(t *testing.T) {
+	cfg := makeJjTestConfig()
+	jjmock := mockjj.NewMockJj(t)
+	ops := NewJjOps(cfg, jjmock, nil)
+
+	commit := git.Commit{CommitID: "00000001", CommitHash: "c100000000000000000000000000000000000000"}
+
+	err := ops.EditStart(commit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no jj change ID")
+	jjmock.ExpectationsMet()
+}
+
+// --- PrepareForPush ---
+
+func TestJjOpsPrepareForPush_IsNoop(t *testing.T) {
+	cfg := makeJjTestConfig()
+	ops := NewJjOps(cfg, nil, nil)
+
+	cleanup, err := ops.PrepareForPush()
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup() // should not panic
+}
+
+// --- mockRootDir implements git.GitInterface just for RootDir ---
+
+type mockRootDir struct {
+	rootDir string
+}
+
+func (m *mockRootDir) GitWithEditor(args string, output *string, editorCmd string) error { return nil }
+func (m *mockRootDir) Git(args string, output *string) error                             { return nil }
+func (m *mockRootDir) MustGit(args string, output *string)                               {}
+func (m *mockRootDir) RootDir() string                                                   { return m.rootDir }
+func (m *mockRootDir) DeleteRemoteBranch(ctx context.Context, branch string) error       { return nil }

--- a/vcs/jj_parse.go
+++ b/vcs/jj_parse.go
@@ -1,0 +1,88 @@
+package vcs
+
+import (
+	"regexp"
+	"strings"
+)
+
+// parsedJjCommit is the intermediate representation of a commit from jj log output.
+type parsedJjCommit struct {
+	commitHash  string // git SHA (from jj's commit_id template keyword)
+	changeID    string // jj change ID
+	empty       bool
+	description string
+	sprCommitID string // extracted from commit-id: trailer, may be ""
+	subject     string
+	body        string
+	wip         bool
+}
+
+// parseJjLogOutput parses output from:
+//
+//	jj log --no-graph --reversed --color=never -r 'trunk()..@'
+//	  -T 'commit_id ++ "\x1f" ++ change_id ++ "\x1f" ++ empty ++ "\x1f" ++ description ++ "\x1e"'
+//
+// Fields are separated by \x1f (unit separator), records by \x1e (record separator).
+// Returns the parsed commits and true if all non-empty commits have commit-id trailers.
+func parseJjLogOutput(output string) ([]parsedJjCommit, bool) {
+	commitIDRegex := regexp.MustCompile(`commit-id:\s*([a-f0-9]{8})`)
+
+	records := strings.Split(output, "\x1e")
+	var commits []parsedJjCommit
+	valid := true
+
+	for _, record := range records {
+		record = strings.TrimSpace(record)
+		if record == "" {
+			continue
+		}
+
+		fields := strings.SplitN(record, "\x1f", 4)
+		if len(fields) < 4 {
+			continue
+		}
+
+		commitHash := strings.TrimSpace(fields[0])
+		changeID := strings.TrimSpace(fields[1])
+		isEmpty := strings.TrimSpace(fields[2]) == "true"
+		description := fields[3]
+
+		// Skip empty commits with no description (working copy placeholder)
+		if isEmpty && strings.TrimSpace(description) == "" {
+			continue
+		}
+
+		// Parse subject and body from description
+		lines := strings.SplitN(strings.TrimSpace(description), "\n", 2)
+		subject := ""
+		body := ""
+		if len(lines) > 0 {
+			subject = strings.TrimSpace(lines[0])
+		}
+		if len(lines) > 1 {
+			body = strings.TrimSpace(lines[1])
+		}
+
+		// Extract commit-id trailer
+		var sprCommitID string
+		matches := commitIDRegex.FindStringSubmatch(description)
+		if matches != nil {
+			sprCommitID = matches[1]
+		} else if !isEmpty {
+			valid = false
+		}
+
+		commits = append(commits, parsedJjCommit{
+			commitHash:  commitHash,
+			changeID:    changeID,
+			empty:       isEmpty,
+			description: description,
+			sprCommitID: sprCommitID,
+			subject:     subject,
+			body:        body,
+			wip:         strings.HasPrefix(subject, "WIP"),
+		})
+	}
+
+	return commits, valid
+}

--- a/vcs/jj_parse_test.go
+++ b/vcs/jj_parse_test.go
@@ -1,0 +1,101 @@
+package vcs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJjLogOutput_SingleCommit(t *testing.T) {
+	input := "c100000000000000000000000000000000000000\x1fmychangeid1234\x1ffalse\x1ftest commit 1\n\ncommit-id:00000001\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.True(t, valid)
+	require.Len(t, commits, 1)
+	assert.Equal(t, "00000001", commits[0].sprCommitID)
+	assert.Equal(t, "mychangeid1234", commits[0].changeID)
+	assert.Equal(t, "c100000000000000000000000000000000000000", commits[0].commitHash)
+	assert.Equal(t, "test commit 1", commits[0].subject)
+	assert.False(t, commits[0].wip)
+	assert.False(t, commits[0].empty)
+}
+
+func TestParseJjLogOutput_MultipleCommits(t *testing.T) {
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ffalse\x1fcommit 1\n\ncommit-id:00000001\n\x1e" +
+		"c200000000000000000000000000000000000000\x1fchange2\x1ffalse\x1fcommit 2\n\ncommit-id:00000002\n\x1e" +
+		"c300000000000000000000000000000000000000\x1fchange3\x1ffalse\x1fcommit 3\n\ncommit-id:00000003\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.True(t, valid)
+	require.Len(t, commits, 3)
+	assert.Equal(t, "00000001", commits[0].sprCommitID)
+	assert.Equal(t, "00000002", commits[1].sprCommitID)
+	assert.Equal(t, "00000003", commits[2].sprCommitID)
+	assert.Equal(t, "change1", commits[0].changeID)
+	assert.Equal(t, "change2", commits[1].changeID)
+	assert.Equal(t, "change3", commits[2].changeID)
+}
+
+func TestParseJjLogOutput_MissingCommitID(t *testing.T) {
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ffalse\x1fcommit without trailer\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.False(t, valid) // invalid because non-empty commit lacks commit-id
+	require.Len(t, commits, 1)
+	assert.Equal(t, "", commits[0].sprCommitID)
+	assert.Equal(t, "change1", commits[0].changeID)
+	assert.Equal(t, "commit without trailer", commits[0].subject)
+}
+
+func TestParseJjLogOutput_EmptyCommitSkipped(t *testing.T) {
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ftrue\x1f\x1e" +
+		"c200000000000000000000000000000000000000\x1fchange2\x1ffalse\x1freal commit\n\ncommit-id:00000001\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.True(t, valid)
+	require.Len(t, commits, 1) // empty commit skipped
+	assert.Equal(t, "change2", commits[0].changeID)
+}
+
+func TestParseJjLogOutput_WIPPrefix(t *testing.T) {
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ffalse\x1fWIP work in progress\n\ncommit-id:00000001\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.True(t, valid)
+	require.Len(t, commits, 1)
+	assert.True(t, commits[0].wip)
+	assert.Equal(t, "WIP work in progress", commits[0].subject)
+}
+
+func TestParseJjLogOutput_MultiLineBody(t *testing.T) {
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ffalse\x1fFix the bug\n\nThis is a detailed\ndescription of the fix.\n\ncommit-id:deadbeef\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.True(t, valid)
+	require.Len(t, commits, 1)
+	assert.Equal(t, "Fix the bug", commits[0].subject)
+	assert.Equal(t, "deadbeef", commits[0].sprCommitID)
+	assert.Contains(t, commits[0].body, "detailed")
+	assert.Contains(t, commits[0].body, "description of the fix")
+}
+
+func TestParseJjLogOutput_EmptyInput(t *testing.T) {
+	commits, valid := parseJjLogOutput("")
+	require.True(t, valid) // no commits = valid (nothing to check)
+	require.Len(t, commits, 0)
+}
+
+func TestParseJjLogOutput_CommitIDWithSpace(t *testing.T) {
+	// commit-id: with a space after colon (spr regex allows this)
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ffalse\x1ftest commit\n\ncommit-id: abcdef01\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.True(t, valid)
+	require.Len(t, commits, 1)
+	assert.Equal(t, "abcdef01", commits[0].sprCommitID)
+}
+
+func TestParseJjLogOutput_MixedValidAndInvalid(t *testing.T) {
+	// First commit has trailer, second doesn't
+	input := "c100000000000000000000000000000000000000\x1fchange1\x1ffalse\x1fcommit 1\n\ncommit-id:00000001\n\x1e" +
+		"c200000000000000000000000000000000000000\x1fchange2\x1ffalse\x1fcommit 2 no trailer\n\x1e"
+	commits, valid := parseJjLogOutput(input)
+	require.False(t, valid) // invalid because second commit lacks trailer
+	require.Len(t, commits, 2)
+	assert.Equal(t, "00000001", commits[0].sprCommitID)
+	assert.Equal(t, "", commits[1].sprCommitID)
+}

--- a/vcs/mockjj/mockjj.go
+++ b/vcs/mockjj/mockjj.go
@@ -1,0 +1,165 @@
+package mockjj
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ejoffe/spr/git"
+	"github.com/stretchr/testify/require"
+)
+
+// NewMockJj creates a new mock jj executor.
+func NewMockJj(t *testing.T) *Mock {
+	return &Mock{
+		assert: require.New(t),
+	}
+}
+
+// Mock implements vcs.JjInterface with expectation-based command verification,
+// following the same pattern as git/mockgit/mockgit.go.
+type Mock struct {
+	assert      *require.Assertions
+	expectedCmd []string
+	response    []responder
+}
+
+// Jj verifies the command matches expectations and returns the configured response.
+func (m *Mock) Jj(args string, output *string) error {
+	fmt.Printf("CMD: jj %s\n", args)
+
+	m.assert.NotEmpty(m.expectedCmd, fmt.Sprintf("Unexpected command: jj %s\n", args))
+
+	expected := m.expectedCmd[0]
+	actual := "jj " + args
+	m.assert.Equal(expected, actual)
+
+	if m.response[0].Valid() {
+		m.assert.NotNil(output)
+		*output = m.response[0].Output()
+	} else if output != nil {
+		*output = ""
+	}
+
+	m.expectedCmd = m.expectedCmd[1:]
+	m.response = m.response[1:]
+
+	return nil
+}
+
+// MustJj calls Jj and panics on error.
+func (m *Mock) MustJj(args string, output *string) {
+	err := m.Jj(args, output)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// JjArgs verifies commands with pre-split arguments.
+func (m *Mock) JjArgs(args []string, output *string) error {
+	return m.Jj(strings.Join(args, " "), output)
+}
+
+// ExpectationsMet verifies all expected commands were called.
+func (m *Mock) ExpectationsMet() {
+	m.assert.Empty(m.expectedCmd, fmt.Sprintf("expected additional jj commands: %v", m.expectedCmd))
+	m.assert.Empty(m.response, fmt.Sprintf("expected additional jj responses: %v", m.response))
+}
+
+// ExpectFetch expects a jj git fetch command.
+func (m *Mock) ExpectFetch() {
+	m.expect("jj git fetch")
+}
+
+// ExpectRebase expects a jj rebase command.
+func (m *Mock) ExpectRebase(remote, branch string) {
+	m.expect(fmt.Sprintf("jj rebase -b @ -d %s@%s", branch, remote))
+}
+
+// ExpectLogAndRespond expects the jj log command and returns formatted output.
+func (m *Mock) ExpectLogAndRespond(commits []*git.Commit) {
+	template := `commit_id ++ "\x1f" ++ change_id ++ "\x1f" ++ empty ++ "\x1f" ++ description ++ "\x1e"`
+	m.expect(fmt.Sprintf(`jj log --no-graph --reversed --color=never -r "trunk()..@" -T '%s'`, template)).
+		respond(formatJjLogResponse(commits))
+}
+
+// ExpectDescribe expects a jj describe command for a specific change.
+func (m *Mock) ExpectDescribe(changeID, message string) {
+	m.expect(fmt.Sprintf("jj describe -r %s -m %s", changeID, message))
+}
+
+// ExpectSquash expects a jj squash --into command.
+func (m *Mock) ExpectSquash(changeID string) {
+	m.expect(fmt.Sprintf("jj squash --into %s", changeID))
+}
+
+// ExpectEdit expects a jj edit command.
+func (m *Mock) ExpectEdit(changeID string) {
+	m.expect(fmt.Sprintf("jj edit %s", changeID))
+}
+
+// ExpectNew expects a jj new command.
+func (m *Mock) ExpectNew(changeID string) {
+	m.expect(fmt.Sprintf("jj new %s", changeID))
+}
+
+// ExpectOpLog expects a jj op log command and returns an operation ID.
+func (m *Mock) ExpectOpLog(opID string) {
+	m.expect("jj op log --no-graph -n 1 -T 'id.short(16)'").respond(opID)
+}
+
+// ExpectOpRestore expects a jj op restore command.
+func (m *Mock) ExpectOpRestore(opID string) {
+	m.expect(fmt.Sprintf("jj op restore %s", opID))
+}
+
+// ExpectLogAt expects a jj log command for the current change ID.
+func (m *Mock) ExpectLogAt(changeID string) {
+	m.expect("jj log --no-graph -r @ -T change_id").respond(changeID)
+}
+
+func (m *Mock) expect(cmd string) *Mock {
+	m.expectedCmd = append(m.expectedCmd, cmd)
+	m.response = append(m.response, &stringResponse{valid: false})
+	return m
+}
+
+func (m *Mock) respond(response string) {
+	m.response[len(m.response)-1] = &stringResponse{
+		valid:  true,
+		output: response,
+	}
+}
+
+type responder interface {
+	Valid() bool
+	Output() string
+}
+
+type stringResponse struct {
+	valid  bool
+	output string
+}
+
+func (r *stringResponse) Valid() bool  { return r.valid }
+func (r *stringResponse) Output() string { return r.output }
+
+// formatJjLogResponse formats commits as jj log output with field/record separators.
+func formatJjLogResponse(commits []*git.Commit) string {
+	var b strings.Builder
+	for _, c := range commits {
+		desc := c.Subject
+		if c.Body != "" {
+			desc += "\n\n" + c.Body
+		}
+		if c.CommitID != "" {
+			desc += "\n\ncommit-id:" + c.CommitID
+		}
+		changeID := c.ChangeID
+		if changeID == "" {
+			changeID = "jjchange_" + c.CommitID
+		}
+		fmt.Fprintf(&b, "%s\x1f%s\x1ffalse\x1f%s\n\x1e", c.CommitHash, changeID, desc)
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Adds [Jujutsu (jj)](https://jj-vcs.github.io/jj/) support to spr. When a `.jj/` directory is detected (jj-colocated repo), spr uses jj-native commands for history-rewriting operations instead of `git rebase`. This preserves jj change IDs across all spr operations.

**Key changes:**
- New `vcs/` package with a `VCSOperations` interface abstracting the 7 operations where git and jj differ
- `GitOps`: pure extraction of existing logic (zero behavior change for git-only repos)
- `JjOps`: jj-native implementation using `jj describe`, `jj rebase`, `jj squash`, `jj edit`
- Auto-detection of `.jj/` directory, with opt-out via `--no-jj` flag, `SPR_NOJJ` env var, or `noJJ: true` in `~/.spr.yml`
- `jj-setup` command to register a `jj spr` alias
- 31 new tests, all existing tests pass unchanged

## Motivation

jj is gaining traction as a git-compatible VCS with a better mental model (immutable commits, change IDs that survive rewrites). spr is the best stacked-PR tool for squash-merge workflows on GitHub. But currently, every `spr update` runs `git rebase`, which destroys jj change IDs in a colocated repo — making the two tools painful to combine.

This PR makes them work together cleanly: spr's commit-id trailers + PR management coexist with jj's change IDs and operation model.

## How it works

| spr operation | git (unchanged) | jj (new) |
|--------------|----------------|----------|
| Fetch + rebase | `git fetch` + `git rebase --autostash` | `jj git fetch` + `jj rebase -b @ -d main@origin` |
| Add commit-id trailers | `git rebase -i` with `spr_reword_helper` | `jj describe -r <change-id>` |
| Amend into commit | `git commit --fixup` + `git rebase -i --autosquash` | `jj squash --into <change-id>` |
| Edit a commit | `git rebase -i` with `edit` stop | `jj edit <change-id>` |
| Stash for push | `git stash` / `git stash pop` | No-op (jj working copy is always a commit) |

Git push, branch management, and all GitHub API calls remain unchanged.

## Backward compatibility

- The `NewStackedPR` constructor accepts `vcsOps` as a variadic parameter — existing callers work without modification
- Auto-detection only activates when `.jj/` exists; plain git repos behave identically to before
- All existing tests pass with `-race`, zero modifications needed
- `commit-id` trailer format is unchanged (`commit-id:XXXXXXXX`)

## Test plan

- [x] 31 new tests covering: detection, factory, opt-out, git ops (5), jj parser (9), jj ops (11), detection + factory (6)
- [x] All existing tests pass unchanged (`go test -race ./...`)
- [ ] Manual testing on a real jj-colocated repo with GitHub PRs (in progress — beta testing on my own repos)

## A note on authorship and process

This PR was developed with significant assistance from Claude (Anthropic's AI), under close human review and direction. Every design decision, architecture choice, and code change was discussed and approved by me before implementation. I am currently beta-testing this on my own repositories.

I'm aware there are varying opinions in the open-source community about AI-assisted contributions and the risk of "drive-by PRs." I want to be fully transparent about the process, and I completely understand if this isn't something you want to merge — feel free to say "thanks but no thanks" with zero hard feelings. I opened this as a draft specifically to invite discussion before any commitment.

If the approach is interesting but the implementation needs changes, I'm happy to iterate. If you'd prefer I rewrite parts without AI assistance, I can do that too.
