### PR TITLE
feat(branch-prefix): add repo-level override

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,9 @@ type RepoConfig struct {
 
 	ForceFetchTags bool `default:"false" yaml:"forceFetchTags"`
 
-	ShowPrTitlesInStack    bool `default:"false" yaml:"showPrTitlesInStack"`
-	BranchPushIndividually bool `default:"false" yaml:"branchPushIndividually"`
+	ShowPrTitlesInStack    bool   `default:"false" yaml:"showPrTitlesInStack"`
+	BranchPushIndividually bool   `default:"false" yaml:"branchPushIndividually"`
+	BranchPrefix           string `yaml:"branchPrefix,omitempty"`
 }
 
 type UserConfig struct {
@@ -51,9 +52,9 @@ type UserConfig struct {
 	StatusBitsHeader bool `default:"true" yaml:"statusBitsHeader"`
 	StatusBitsEmojis bool `default:"true" yaml:"statusBitsEmojis"`
 
-	CreateDraftPRs       bool `default:"false" yaml:"createDraftPRs"`
-	PreserveTitleAndBody bool `default:"false" yaml:"preserveTitleAndBody"`
-	NoRebase             bool `default:"false" yaml:"noRebase"`
+	CreateDraftPRs       bool   `default:"false" yaml:"createDraftPRs"`
+	PreserveTitleAndBody bool   `default:"false" yaml:"preserveTitleAndBody"`
+	NoRebase             bool   `default:"false" yaml:"noRebase"`
 	NoFetch              bool `default:"false" yaml:"noFetch"`
 	DeleteMergedBranches bool `default:"false" yaml:"deleteMergedBranches"`
 	ShortPRLink          bool `default:"false" yaml:"shortPRLink"`
@@ -102,6 +103,14 @@ func (c *Config) Normalize() {
 	if c.Repo != nil && c.Repo.PRTemplatePath != "" {
 		c.Repo.PRTemplateType = "custom"
 	}
+}
+
+func (c Config) BranchPrefix() string {
+	prefix := c.User.BranchPrefix
+	if c.Repo != nil && c.Repo.BranchPrefix != "" {
+		prefix = c.Repo.BranchPrefix
+	}
+	return strings.TrimRight(prefix, "/")
 }
 
 func (c Config) MergeMethod() (genclient.PullRequestMergeMethod, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,6 +93,40 @@ func TestMergeMethodHelper(t *testing.T) {
 	})
 }
 
+func TestBranchPrefix(t *testing.T) {
+	t.Run("returns user default when repo is empty", func(t *testing.T) {
+		cfg := &Config{
+			Repo: &RepoConfig{},
+			User: &UserConfig{BranchPrefix: "spr"},
+		}
+		assert.Equal(t, "spr", cfg.BranchPrefix())
+	})
+
+	t.Run("repo overrides user", func(t *testing.T) {
+		cfg := &Config{
+			Repo: &RepoConfig{BranchPrefix: "team-x"},
+			User: &UserConfig{BranchPrefix: "spr"},
+		}
+		assert.Equal(t, "team-x", cfg.BranchPrefix())
+	})
+
+	t.Run("falls back to user when repo not set", func(t *testing.T) {
+		cfg := &Config{
+			Repo: &RepoConfig{},
+			User: &UserConfig{BranchPrefix: "custom"},
+		}
+		assert.Equal(t, "custom", cfg.BranchPrefix())
+	})
+
+	t.Run("strips trailing slash", func(t *testing.T) {
+		cfg := &Config{
+			Repo: &RepoConfig{BranchPrefix: "johndoe/spr/"},
+			User: &UserConfig{BranchPrefix: "spr"},
+		}
+		assert.Equal(t, "johndoe/spr", cfg.BranchPrefix())
+	})
+}
+
 func TestNormalizeConfig(t *testing.T) {
 	t.Run("PRTemplatePath provided sets PRTemplateType to custom", func(t *testing.T) {
 		cfg := &Config{

--- a/git/helpers.go
+++ b/git/helpers.go
@@ -26,7 +26,7 @@ func GetLocalBranchName(gitcmd GitInterface) string {
 
 func BranchNameFromCommit(cfg *config.Config, commit Commit) string {
 	remoteBranchName := cfg.Repo.GitHubBranch
-	branchPrefix := cfg.User.BranchPrefix
+	branchPrefix := cfg.BranchPrefix()
 	return branchPrefix + "/" + remoteBranchName + "/" + commit.CommitID
 }
 

--- a/git/helpers_test.go
+++ b/git/helpers_test.go
@@ -83,3 +83,14 @@ func TestBranchNameFromCommit(t *testing.T) {
 		})
 	}
 }
+
+func TestBranchNameFromCommitRepoOverride(t *testing.T) {
+	cfg := config.EmptyConfig()
+	cfg.User.BranchPrefix = "spr"
+	cfg.Repo.BranchPrefix = "team-x"
+	cfg.Repo.GitHubBranch = "main"
+
+	commit := Commit{CommitID: "deadbeef"}
+	result := BranchNameFromCommit(cfg, commit)
+	assert.Equal(t, "team-x/main/deadbeef", result)
+}

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -216,7 +216,7 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 	targetBranch := c.config.Repo.GitHubBranch
 	localCommitStack := git.GetLocalCommitStack(c.config, gitcmd)
 
-	pullRequests := matchPullRequestStack(c.config.Repo, c.config.User.BranchPrefix, targetBranch, localCommitStack, pullRequestConnection)
+	pullRequests := matchPullRequestStack(c.config.Repo, c.config.BranchPrefix(), targetBranch, localCommitStack, pullRequestConnection)
 
 	// When RequiredChecks is explicitly configured, fetch individual check contexts
 	// and only evaluate the listed checks. This allows non-required check failures

--- a/spr/spr.go
+++ b/spr/spr.go
@@ -663,7 +663,7 @@ func (sd *stackediff) fetchAndGetGitHubInfo(ctx context.Context) *github.GitHubI
 		return nil
 	}
 	info := sd.github.GetInfo(ctx, sd.gitcmd)
-	if git.BranchNameRegex(sd.config.User.BranchPrefix).FindString(info.LocalBranch) != "" {
+	if git.BranchNameRegex(sd.config.BranchPrefix()).FindString(info.LocalBranch) != "" {
 		fmt.Printf("error: don't run spr in a remote pr branch\n")
 		fmt.Printf(" this could lead to weird duplicate pull requests getting created\n")
 		fmt.Printf(" in general there is no need to checkout remote branches used for prs\n")


### PR DESCRIPTION
Implement the repo-level `branchPrefix` config option that PR #494
announced in its commit message ("It can be set at user level or at
repo level, with repo taking precedence") but didn't ship in the code.

Introduce `Config.BranchPrefix()` helper that returns the effective
prefix with the precedence rule applied and trims any trailing slash.
All call sites in git/helpers.go, github/githubclient/client.go and
spr/spr.go are updated to use this helper instead of reading
User.BranchPrefix directly.

Related to #494
