### PR TITLE
fix(template): render stack section from caller-supplied order

### DIFF
--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -424,7 +424,7 @@ func (c *client) CreatePullRequest(ctx context.Context, gitcmd git.GitInterface,
 
 	templatizer := config_fetcher.PRTemplatizer(c.config, gitcmd)
 
-	body := templatizer.Body(info, commit, nil)
+	body := templatizer.Body(info, info.PullRequests, commit, nil)
 	resp, err := c.api.CreatePullRequest(ctx, genclient.CreatePullRequestInput{
 		RepositoryId: info.RepositoryID,
 		BaseRefName:  baseRefName,
@@ -473,7 +473,7 @@ func (c *client) UpdatePullRequest(ctx context.Context, gitcmd git.GitInterface,
 
 	templatizer := config_fetcher.PRTemplatizer(c.config, gitcmd)
 	title := templatizer.Title(info, commit)
-	body := templatizer.Body(info, commit, pr)
+	body := templatizer.Body(info, pullRequests, commit, pr)
 
 	// Skip the API call if nothing has actually changed. This avoids
 	// triggering a spurious pull_request "edited" event on GitHub which

--- a/github/template/interface.go
+++ b/github/template/interface.go
@@ -7,5 +7,8 @@ import (
 
 type PRTemplatizer interface {
 	Title(info *github.GitHubInfo, commit git.Commit) string
-	Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string
+	// Body renders the PR body. stack is the ordered list of PRs in the
+	// stack (bottom to top) used to render the stack section, independent
+	// from info.PullRequests which may carry an unrelated order.
+	Body(info *github.GitHubInfo, stack []*github.PullRequest, commit git.Commit, pr *github.PullRequest) string
 }

--- a/github/template/template_basic/template.go
+++ b/github/template/template_basic/template.go
@@ -16,7 +16,8 @@ func (t *BasicTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) str
 	return commit.Subject
 }
 
-func (t *BasicTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
+func (t *BasicTemplatizer) Body(info *github.GitHubInfo, stack []*github.PullRequest, commit git.Commit, pr *github.PullRequest) string {
+	_ = stack // basic template doesn't render the stack section
 	body := commit.Body
 	body += "\n\n"
 	body += template.ManualMergeNotice()

--- a/github/template/template_basic/template_test.go
+++ b/github/template/template_basic/template_test.go
@@ -194,7 +194,7 @@ func TestBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := templatizer.Body(info, tt.commit, nil)
+			got := templatizer.Body(info, info.PullRequests,tt.commit, nil)
 
 			// Verify all expected strings are present
 			for _, wantStr := range tt.wantContains {
@@ -229,7 +229,7 @@ func TestBodyManualMergeNoticeFormat(t *testing.T) {
 		Body:    "Test body",
 	}
 
-	result := templatizer.Body(info, commit, nil)
+	result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 	// Verify the exact format of the manual merge notice
 	expectedNotice := "⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*"
@@ -280,7 +280,7 @@ func TestBodyPreservesOriginalContent(t *testing.T) {
 				Body:    tc.body,
 			}
 
-			result := templatizer.Body(info, commit, nil)
+			result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 			// The result should contain the original body (if not empty)
 			if tc.body != "" {
@@ -349,7 +349,7 @@ Performance improvements:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := templatizer.Body(info, tt.commit, nil)
+			result := templatizer.Body(info, info.PullRequests,tt.commit, nil)
 
 			// Should contain the original body content
 			assert.Contains(t, result, tt.commit.Body)

--- a/github/template/template_custom/template.go
+++ b/github/template/template_custom/template.go
@@ -36,8 +36,8 @@ func (t *CustomTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) st
 	return commit.Subject
 }
 
-func (t *CustomTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
-	body := t.formatBody(commit, info.PullRequests)
+func (t *CustomTemplatizer) Body(info *github.GitHubInfo, stack []*github.PullRequest, commit git.Commit, pr *github.PullRequest) string {
+	body := t.formatBody(commit, stack)
 	pullRequestTemplate, err := t.readPRTemplate()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to read PR template")

--- a/github/template/template_stack/template.go
+++ b/github/template/template_stack/template.go
@@ -18,14 +18,14 @@ func (t *StackTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) str
 	return commit.Subject
 }
 
-func (t *StackTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
+func (t *StackTemplatizer) Body(info *github.GitHubInfo, stack []*github.PullRequest, commit git.Commit, pr *github.PullRequest) string {
 	body := commit.Body
 
 	// Always show stack section and notice
 	body += "\n\n"
 	body += "---\n"
 	body += "**Stack**:\n"
-	body += template.FormatStackMarkdown(commit, info.PullRequests, t.showPrTitlesInStack)
+	body += template.FormatStackMarkdown(commit, stack, t.showPrTitlesInStack)
 	body += "---\n"
 	body += template.ManualMergeNotice()
 	return body

--- a/github/template/template_stack/template_test.go
+++ b/github/template/template_stack/template_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ejoffe/spr/git"
 	"github.com/ejoffe/spr/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTitle(t *testing.T) {
@@ -79,7 +80,7 @@ func TestBody_EmptyStack(t *testing.T) {
 		Body:    "Commit body text",
 	}
 
-	result := templatizer.Body(info, commit, nil)
+	result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 	// Should contain the commit body
 	assert.Contains(t, result, "Commit body text")
@@ -133,7 +134,7 @@ func TestBody_WithStack_NoTitles(t *testing.T) {
 	}
 
 	// Test with commit2 (middle of stack)
-	result := templatizer.Body(info, commit2, nil)
+	result := templatizer.Body(info, info.PullRequests,commit2, nil)
 
 	// Should contain the commit body
 	assert.Contains(t, result, "Second body")
@@ -210,7 +211,7 @@ func TestBody_WithStack_WithTitles(t *testing.T) {
 	}
 
 	// Test with commit2 (middle of stack)
-	result := templatizer.Body(info, commit2, nil)
+	result := templatizer.Body(info, info.PullRequests,commit2, nil)
 
 	// Should contain the commit body
 	assert.Contains(t, result, "Second body")
@@ -254,7 +255,7 @@ func TestBody_StackOrder(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit2, nil)
+	result := templatizer.Body(info, info.PullRequests,commit2, nil)
 
 	// Stack should be in reverse order (3, 2, 1)
 	// Find the stack section
@@ -305,7 +306,7 @@ func TestBody_CurrentCommitAtStart(t *testing.T) {
 	}
 
 	// Test with commit3 (last in stack, first in reverse order)
-	result := templatizer.Body(info, commit3, nil)
+	result := templatizer.Body(info, info.PullRequests,commit3, nil)
 
 	// Should have arrow on #3
 	assert.Contains(t, result, "#3 ⬅")
@@ -343,7 +344,7 @@ func TestBody_CurrentCommitAtEnd(t *testing.T) {
 	}
 
 	// Test with commit1 (first in stack, last in reverse order)
-	result := templatizer.Body(info, commit1, nil)
+	result := templatizer.Body(info, info.PullRequests,commit1, nil)
 
 	// Should have arrow on #1
 	assert.Contains(t, result, "#1 ⬅")
@@ -368,7 +369,7 @@ func TestBody_EmptyBody(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit, nil)
+	result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 	// Should still contain stack and notice
 	assert.Contains(t, result, "#1")
@@ -391,7 +392,7 @@ func TestBody_SinglePRInStack(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit, nil)
+	result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 	// Should contain the body
 	assert.Contains(t, result, "Single body")
@@ -427,7 +428,7 @@ func TestBody_WithTitlesVsWithoutTitles(t *testing.T) {
 
 	// Test without titles
 	templatizerNoTitles := NewStackTemplatizer(false)
-	resultNoTitles := templatizerNoTitles.Body(info, commit2, nil)
+	resultNoTitles := templatizerNoTitles.Body(info, info.PullRequests, commit2, nil)
 
 	// Should NOT contain PR titles
 	assert.NotContains(t, resultNoTitles, "First PR")
@@ -438,7 +439,7 @@ func TestBody_WithTitlesVsWithoutTitles(t *testing.T) {
 
 	// Test with titles
 	templatizerWithTitles := NewStackTemplatizer(true)
-	resultWithTitles := templatizerWithTitles.Body(info, commit2, nil)
+	resultWithTitles := templatizerWithTitles.Body(info, info.PullRequests, commit2, nil)
 
 	// Should contain PR titles
 	assert.Contains(t, resultWithTitles, "First PR #1")
@@ -460,7 +461,7 @@ func TestBody_Structure(t *testing.T) {
 		},
 	}
 
-	result := templatizer.Body(info, commit, nil)
+	result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 	// Verify structure: body + \n\n + stack + \n\n + notice
 	// The body should come first
@@ -513,7 +514,7 @@ func TestBody_RealWorldExample(t *testing.T) {
 	}
 
 	// Test with middle commit
-	result := templatizer.Body(info, commit2, nil)
+	result := templatizer.Body(info, info.PullRequests,commit2, nil)
 
 	// Should contain commit body
 	assert.Contains(t, result, "Created POST /login endpoint")
@@ -611,12 +612,69 @@ It even includes some **markdown** formatting.
 	templatizer := NewStackTemplatizer(false)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			body := templatizer.Body(tc.info, tc.commit, nil)
+			body := templatizer.Body(tc.info, tc.info.PullRequests, tc.commit, nil)
 			if body != tc.expected {
 				t.Fatalf("expected: '%v', actual: '%v'", tc.expected, body)
 			}
 		})
 	}
+}
+
+// TestBody_StackArgOverridesInfoOrder reproduces the bug where the rendered
+// stack section followed info.PullRequests' insertion order instead of the
+// logical stack order computed by the caller.
+//
+// Scenario mirrors what spr.UpdatePullRequests produces after a reorder +
+// new commits are inserted: the existing PR (#65362, top of new stack) is
+// kept at index 0 of info.PullRequests by an append-loop, while the
+// freshly-created PRs (#65417, #65418, #65419) are appended after it.
+// The caller already computed the correctly-sorted stack and passes it via
+// the `stack` argument; the body must reflect that stack, not info's order.
+func TestBody_StackArgOverridesInfoOrder(t *testing.T) {
+	templatizer := NewStackTemplatizer(false)
+
+	cBottom := git.Commit{CommitID: "65417", Subject: "C", Body: "C body"}
+	cMid1 := git.Commit{CommitID: "65418", Subject: "D", Body: "D body"}
+	cMid2 := git.Commit{CommitID: "65419", Subject: "E", Body: "E body"}
+	cTop := git.Commit{CommitID: "65362", Subject: "B", Body: "B body"}
+
+	prBottom := &github.PullRequest{Number: 65417, Commit: cBottom}
+	prMid1 := &github.PullRequest{Number: 65418, Commit: cMid1}
+	prMid2 := &github.PullRequest{Number: 65419, Commit: cMid2}
+	prTop := &github.PullRequest{Number: 65362, Commit: cTop}
+
+	// info.PullRequests is in append/insertion order — the buggy state.
+	// The pre-existing prTop sits at index 0; the newly-created PRs were
+	// appended after it.
+	info := &github.GitHubInfo{
+		PullRequests: []*github.PullRequest{prTop, prBottom, prMid1, prMid2},
+	}
+
+	// stack carries the logical order: bottom -> top.
+	stack := []*github.PullRequest{prBottom, prMid1, prMid2, prTop}
+
+	// Render the body for the bottom PR (#65417, the current PR).
+	body := templatizer.Body(info, stack, cBottom, prBottom)
+
+	// FormatStackMarkdown lists the stack from top down, so we expect:
+	//   - #65362
+	//   - #65419
+	//   - #65418
+	//   - #65417 ⬅
+	idxTop := strings.Index(body, "#65362")
+	idxMid2 := strings.Index(body, "#65419")
+	idxMid1 := strings.Index(body, "#65418")
+	idxBot := strings.Index(body, "#65417 ⬅")
+
+	require.NotEqual(t, -1, idxTop, "should contain #65362")
+	require.NotEqual(t, -1, idxMid2, "should contain #65419")
+	require.NotEqual(t, -1, idxMid1, "should contain #65418")
+	require.NotEqual(t, -1, idxBot, "current PR #65417 should carry the arrow")
+
+	// top first, current PR last
+	require.Less(t, idxTop, idxMid2, "#65362 (top) must precede #65419")
+	require.Less(t, idxMid2, idxMid1, "#65419 must precede #65418")
+	require.Less(t, idxMid1, idxBot, "#65418 must precede #65417 (current/bottom)")
 }
 
 /*

--- a/github/template/template_why_what/template.go
+++ b/github/template/template_why_what/template.go
@@ -20,7 +20,7 @@ func (t *WhyWhatTemplatizer) Title(info *github.GitHubInfo, commit git.Commit) s
 	return commit.Subject
 }
 
-func (t *WhyWhatTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr *github.PullRequest) string {
+func (t *WhyWhatTemplatizer) Body(info *github.GitHubInfo, stack []*github.PullRequest, commit git.Commit, pr *github.PullRequest) string {
 	// Split commit body by empty lines and filter out empty sections
 	sections := splitByEmptyLines(commit.Body)
 
@@ -67,7 +67,7 @@ func (t *WhyWhatTemplatizer) Body(info *github.GitHubInfo, commit git.Commit, pr
 	body += "\n"
 	body += "---\n"
 	body += "**Stack**:\n"
-	body += template.FormatStackMarkdown(commit, info.PullRequests, true)
+	body += template.FormatStackMarkdown(commit, stack, true)
 	body += "---\n"
 	body += template.ManualMergeNotice()
 	return body

--- a/github/template/template_why_what/template_test.go
+++ b/github/template/template_why_what/template_test.go
@@ -212,7 +212,7 @@ func TestBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := templatizer.Body(info, tt.commit, nil)
+			got := templatizer.Body(info, info.PullRequests,tt.commit, nil)
 
 			// Check that all required strings are present
 			for _, wantStr := range tt.contains {
@@ -320,7 +320,7 @@ func TestBodyTemplateStructure(t *testing.T) {
 		Body:    "Why section\n\nWhat changed section\n\nTest plan section",
 	}
 
-	result := templatizer.Body(info, commit, nil)
+	result := templatizer.Body(info, info.PullRequests,commit, nil)
 
 	// Verify sections appear in correct order
 	whyIndex := strings.Index(result, "Why\n===")
@@ -381,7 +381,7 @@ Manual review of the docs.`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := templatizer.Body(info, tt.commit, nil)
+			result := templatizer.Body(info, info.PullRequests,tt.commit, nil)
 
 			// Should always contain the required sections
 			assert.Contains(t, result, "Why\n===")


### PR DESCRIPTION
The PR body's stack list was generated from info.PullRequests, which holds whatever insertion order spr.UpdatePullRequests produced — after a reorder + new commits are appended, the pre-existing top PR ends up at index 0 and is rendered at the bottom of every body's stack section.

PRTemplatizer.Body now takes an explicit stack []*github.PullRequest. UpdatePullRequest forwards its already-sorted pullRequests parameter; CreatePullRequest forwards info.PullRequests as before.

Regression test in template_stack feeds a misordered info and a correctly-ordered stack, and asserts the rendered markdown follows the stack arg.