### PR TITLE
ci: fix systematic CI error by pinning goreleaser to v2.15.4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,16 @@ jobs:
     - name: Check goreleaser file
       uses: goreleaser/goreleaser-action@v6.2.1
       with:
-        version: latest
+        # Pinned: goreleaser v2.16.0 (2026-05-24) started treating the
+        # deprecated `brews:` key in .goreleaser.yml as a hard error,
+        # breaking CI on every push. v2.15.4 (2026-04-21, the last
+        # release before the strict check) still accepts `brews:` with
+        # only a warning AND understands the current `formats:` syntax
+        # under `archives.format_overrides`. Unpin once .goreleaser.yml
+        # is updated (likely either drop the brews block or migrate it
+        # to whatever goreleaser eventually settles on as the homebrew
+        # successor).
+        version: 'v2.15.4'
         args: check
 
     #- name: Upload coverage


### PR DESCRIPTION
goreleaser v2.16.0 (2026-05-24) turned the deprecated `brews:` key in `.goreleaser.yml` into a hard error. With `version: latest`, **every push since fails CI's `goreleaser check` step regardless of the code change.**

v2.15.4 (2026-04-21) is the latest release that still accepts `brews:` with only a warning and also understands the current `archives.format_overrides.formats` syntax. Pinning to it restores green CI without touching `.goreleaser.yml`.

## Migration path (for whoever unpins)

The goreleaser deprecation page recommends migrating `brews:` → `homebrew_casks:`. For simple cases this is a key rename, plus a `hooks.post.install` block to strip the macOS quarantine xattr (because the binaries aren't signed/notarized).

End-user impact:

- **macOS:** transparent. The binary still lands at `/opt/homebrew/bin/git-spr` (via the cask `binary` stanza) — same PATH, same usage. The install command may need `--cask` explicitly in the readme.
- **Linux:** regression. Casks are macOS-only; Linux brew users currently installing via `brew install ejoffe/tap/spr` would have to switch to another channel (binary release, apt, Nix, source).
- **Tap repo:** `Formula/spr.rb` becomes `Casks/spr.rb`. The `ejoffe/homebrew-tap` repo would need a transition plan.

Alternative: drop `brews:` entirely and remove the brew install path from the readme. Simpler but breaks the channel outright.

Either way it's a deliberate distribution decision, not a mechanical CI fix, which is why this PR pins rather than migrates.

Unpin once the `brews:` block is migrated or removed.


---

*Full transparency: I made heavy use of Claude Code (Opus 4.7, high effort) for this PR, as I do for my own work these days.*
